### PR TITLE
Bugfix issue #26: Document that destinationCACertificate must be dele…

### DIFF
--- a/charts/microgateway/README.md
+++ b/charts/microgateway/README.md
@@ -641,6 +641,7 @@ Therefore, no certificates need to be configured on the Route and termination ta
     tls:
       enabled: true
       termination: passthrough
+      destinationCACertificate: ""
   ```
 
 ## Security

--- a/charts/microgateway/README.md.gotmpl
+++ b/charts/microgateway/README.md.gotmpl
@@ -552,6 +552,7 @@ Therefore, no certificates need to be configured on the Route and termination ta
     tls:
       enabled: true
       termination: passthrough
+      destinationCACertificate: ""
   ```
 
 ## Security


### PR DESCRIPTION
## Description
Document that destinationCACertificate must be deleted in combination with passthrough.

- Bug fix #26

## Type of change
- [x] Documentation

## Checklist:
- [x] The code has been reviewed (self-review, ...).
- [x] The corresponding documentation has been updated.