### PR TITLE
Microgateway documentation improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+helm-docs:
+	@echo --- Generating Chart READMEs
+	@docker run --rm -v $$(pwd):/helm-docs -u $$(id -u) jnorwood/helm-docs:v0.13.0

--- a/charts/microgateway/README.md
+++ b/charts/microgateway/README.md
@@ -216,7 +216,8 @@ config:
       ---------------------
 ```
 
-2. Deploy the Microgateway with the license.yaml file:
+2. [Create the image pull secret](#credentials-to-pull-image-from-docker-registry) to pull the microgateway image.
+3. Deploy the Microgateway with the license.yaml file:
   ```console
   helm upgrade -i microgateway airlock/microgateway -f license.yaml
   ```
@@ -344,15 +345,15 @@ By default, the Airlock Microgateway is configured with the [Simple DSL configur
         entry_path: /
         operational_mode: integration
         deny_rules:
-          - level: strict
-            exceptions:
-              - parameter_name:
-                  pattern: ^content$
-                  ignore_case: true
-                path:
-                  pattern: ^/mail/
-                method:
-                  pattern: ^POST$
+          level: strict
+          exceptions:
+            - parameter_name:
+                pattern: ^content$
+                ignore_case: true
+              path:
+                pattern: ^/mail/
+              method:
+                pattern: ^POST$
       backend:
         protocol: https
         hostname: custom-backend-service
@@ -408,15 +409,15 @@ The use cases outlined above can also occur slightly differently. But all of the
               operational_mode: integration
               session_handling: enforce_session
               deny_rules:
-                - level: standard
-                  exceptions:
-                    - parameter_name:
-                        pattern: ^content$
-                        ignore_case: true
-                      path:
-                        pattern: ^/mail/
-                      method:
-                        pattern: ^POST$
+                level: standard
+                exceptions:
+                  - parameter_name:
+                      pattern: ^content$
+                      ignore_case: true
+                    path:
+                      pattern: ^/mail/
+                    method:
+                      pattern: ^POST$
             - name: api
               entry_path: /api/
               session_handling: ignore_session
@@ -624,7 +625,7 @@ In case that multiple hosts are configured, TLS-SNI is used to distinguish what 
   ```
 
 ### Openshift Route
-Since the Route is already available in an Openshift environment, nothing has to be installed additionally.
+Since the Route controller is already available in an Openshift environment, nothing has to be installed additionally.
 
 #### Route terminating HTTP
 

--- a/charts/microgateway/README.md.gotmpl
+++ b/charts/microgateway/README.md.gotmpl
@@ -123,7 +123,8 @@ config:
       ---------------------
 ```
 
-2. Deploy the Microgateway with the license.yaml file:
+2. [Create the image pull secret](#credentials-to-pull-image-from-docker-registry) to pull the microgateway image.
+3. Deploy the Microgateway with the license.yaml file:
   ```console
   helm upgrade -i microgateway airlock/microgateway -f license.yaml
   ```
@@ -248,15 +249,15 @@ By default, the Airlock Microgateway is configured with the [Simple DSL configur
         entry_path: /
         operational_mode: integration
         deny_rules:
-          - level: strict
-            exceptions:
-              - parameter_name:
-                  pattern: ^content$
-                  ignore_case: true
-                path:
-                  pattern: ^/mail/
-                method:
-                  pattern: ^POST$
+          level: strict
+          exceptions:
+            - parameter_name:
+                pattern: ^content$
+                ignore_case: true
+              path:
+                pattern: ^/mail/
+              method:
+                pattern: ^POST$
       backend:
         protocol: https
         hostname: custom-backend-service
@@ -312,15 +313,15 @@ The use cases outlined above can also occur slightly differently. But all of the
               operational_mode: integration
               session_handling: enforce_session
               deny_rules:
-                - level: standard
-                  exceptions:
-                    - parameter_name:
-                        pattern: ^content$
-                        ignore_case: true
-                      path:
-                        pattern: ^/mail/
-                      method:
-                        pattern: ^POST$
+                level: standard
+                exceptions:
+                  - parameter_name:
+                      pattern: ^content$
+                      ignore_case: true
+                    path:
+                      pattern: ^/mail/
+                    method:
+                      pattern: ^POST$
             - name: api
               entry_path: /api/
               session_handling: ignore_session
@@ -528,7 +529,7 @@ In case that multiple hosts are configured, TLS-SNI is used to distinguish what 
   ```
 
 ### Openshift Route
-Since the Route is already available in an Openshift environment, nothing has to be installed additionally.
+Since the Route controller is already available in an Openshift environment, nothing has to be installed additionally.
 
 #### Route terminating HTTP
 


### PR DESCRIPTION
## Description
* Adds a Makefile
* Improve README documentation of microgateway

Closes: #59 

## Motivation
* Make documentation more accessible
* Make editing of Chart READMEs easier by only having to modify README.md.gotmpl and let helm-docs regenerate the actual README.md

## Type of change.

- [x] Bug fix (non-breaking change)
- [x] Feature (non-breaking change)
- [x] Documentation

## How has this been tested?

- Edited `charts/microgateway/README.md.gotmpl`
- `make helm-docs`
- Verify `charts/microgateway/README.md` has been updated to mirror the changes from Go template file

**Versions**
* Microgateway: irrelevant
* Helm Chart: 0.6.0
* Helm client: irrelevant
* Kubernetes / Openshift: irrelevant

## Checklist:
- [x] The code has been reviewed (self-review, ...).
- [ ] The parts of the code which are hard to understand are commented.
- [x] The corresponding documentation has been updated.
- [ ] The changes do not cause warnings.
- [x] The spelling has been checked.