### PR TITLE
Change imagePullPolicy default value

### DIFF
--- a/charts/microgateway/Chart.yaml
+++ b/charts/microgateway/Chart.yaml
@@ -14,5 +14,5 @@ maintainers:
   - email: support@airlock.com
     name: Airlock
 name: microgateway
-version: 0.6.0
+version: 0.6.1
 appVersion: 1.0

--- a/charts/microgateway/README.md
+++ b/charts/microgateway/README.md
@@ -6,7 +6,7 @@ It is the lightweight, container-based deployment form of the *Airlock Gateway*,
 
 The Airlock helm charts are used internally for testing the *Airlock Microgateway*. We make them available publicly under the [MIT license](https://github.com/ergon/airlock-helm-charts/blob/master/LICENSE).
 
-The current chart version is: 0.6.0
+The current chart version is: 0.6.1
 
 ## About Ergon
 *Airlock* is a registered trademark of [Ergon](https://www.ergon.ch). Ergon is a Swiss leader in leveraging digitalisation to create unique and effective client benefits, from conception to market, the result of which is the international distribution of globally revered products.
@@ -136,7 +136,7 @@ The following table lists configuration parameters of the Airlock Microgateway c
 | hpa.minReplicas | int | `1` | Minimum number of Microgateway replicas. |
 | hpa.resource.cpu | int | `50` | Average Microgateway CPU consumption in percentage to scale up/down. |
 | hpa.resource.memory | string | `"2Gi"` | Average Microgateway Memory consumption to scale up/down.<br><br> :exclamation: Update this setting accordingly to `resources.limits.memory`. |
-| image.pullPolicy | string | `"Always"` | Pull policy (`Always`, `IfNotPresent`, `Never`) |
+| image.pullPolicy | string | `"IfNotPresent"` | Pull policy (`Always`, `IfNotPresent`, `Never`) |
 | image.repository | string | `"ergon/airlock-microgateway"` | Image repository |
 | image.tag | string | `"1.0"` | Image tag |
 | imagePullSecrets | list | `[]` | Reference to one or more secrets to use when pulling images. |

--- a/charts/microgateway/values.yaml
+++ b/charts/microgateway/values.yaml
@@ -7,7 +7,7 @@ image:
   # image.tag -- Image tag
   tag: "1.0"
   # image.pullPolicy -- Pull policy (`Always`, `IfNotPresent`, `Never`)
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
 
 ## Microgateway Config
 ##


### PR DESCRIPTION
## Description
* Change `imagePullPolicy` default value to `IfNotPresent`

## Motivation
When using SemVer with image tags, the imagePullPolicy could be set to "IfNotPresent" by default. This will reduce the startup of microgateway, since the same image does not need to be pulled again. One can (usually safely) assume that an image tag like "1.0" stays the same and thus can pin the image version. There won't be the need to pull the image again.

## Type of change

- [x] Bug fix (non-breaking change)
- [ ] Bug fix (breaking change, which have impact to existing functionality)
- [ ] Feature (non-breaking change)
- [ ] Feature (breaking change, which have impact to existing functionality)
- [ ] Documentation

## How has this been tested?
Not tested

**Versions**
* Microgateway: irrelevant
* Helm Chart: 0.6.0
* Helm client: v3.1.2
* Kubernetes / Openshift: irrelevant

## Checklist:
- [x] The code has been reviewed (self-review, ...).
- [ ] The parts of the code which are hard to understand are commented.
- [x] The corresponding documentation has been updated.
- [x] The changes do not cause warnings.
- [x] The spelling has been checked.
