### PR TITLE
Adjust liveness probe values

### DIFF
--- a/charts/microgateway/Chart.yaml
+++ b/charts/microgateway/Chart.yaml
@@ -14,5 +14,5 @@ maintainers:
   - email: support@airlock.com
     name: Airlock
 name: microgateway
-version: 0.6.0
+version: 0.6.1
 appVersion: 1.0

--- a/charts/microgateway/README.md
+++ b/charts/microgateway/README.md
@@ -6,7 +6,7 @@ It is the lightweight, container-based deployment form of the *Airlock Gateway*,
 
 The Airlock helm charts are used internally for testing the *Airlock Microgateway*. We make them available publicly under the [MIT license](https://github.com/ergon/airlock-helm-charts/blob/master/LICENSE).
 
-The current chart version is: 0.6.0
+The current chart version is: 0.6.1
 
 ## About Ergon
 *Airlock* is a registered trademark of [Ergon](https://www.ergon.ch). Ergon is a Swiss leader in leveraging digitalisation to create unique and effective client benefits, from conception to market, the result of which is the international distribution of globally revered products.
@@ -149,12 +149,15 @@ The following table lists configuration parameters of the Airlock Microgateway c
 | ingress.targetPort | string | `"http"` | Target port of the service (`http`, `https` or `<number>`). |
 | ingress.tls | list | `[]` | [Ingress TLS](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) configuration. |
 | livenessProbe.enabled | bool | `true` | Enable liveness probes. |
+| livenessProbe.failureThreshold | int | `9` | After how many subsequent failures the pod gets restarted. |
 | livenessProbe.initialDelaySeconds | int | `90` | Initial delay in seconds. |
+| livenessProbe.timeoutSeconds | int | `5` | Timeout of liveness probes, should roughly reflect allowed timeouts from clients. |
 | nameOverride | string | `""` | Provide a name in place of `microgateway`. |
 | nodeSelector | object | `{}` | Define which nodes the pods are scheduled on. |
 | podSecurityContext | object | `{}` | [Security context for the pods](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod). |
 | readinessProbe.enabled | bool | `true` | Enable readiness probes. |
-| readinessProbe.initialDelaySeconds | int | `30` | Initial delay in seconds. |
+| readinessProbe.failureThreshold | int | `3` | After how many tries the pod stops receiving traffic. |
+| readinessProbe.initialDelaySeconds | int | `10` | Initial delay in seconds. |
 | redis | object | See `redis.*`: | Pre-configured [Redis](#redis) service. |
 | redis.enabled | bool | `false` | Deploy pre-configured [Redis](#redis). |
 | replicaCount | int | `1` | Desired number of Microgateway pods. |

--- a/charts/microgateway/templates/deployment.yaml
+++ b/charts/microgateway/templates/deployment.yaml
@@ -54,6 +54,8 @@ spec:
         {{- end }}
         {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
           httpGet:
             path: /healthz
             port: http
@@ -61,11 +63,18 @@ spec:
         {{- end }}
         {{- if .Values.readinessProbe.enabled }}
         readinessProbe:
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
           httpGet:
             path: /healthz
             port: http
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
         {{- end }}
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /usr/bin/sleep
+              - "10"
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
         securityContext:

--- a/charts/microgateway/values.yaml
+++ b/charts/microgateway/values.yaml
@@ -282,12 +282,19 @@ livenessProbe:
   enabled: true
   # livenessProbe.initialDelaySeconds -- Initial delay in seconds.
   initialDelaySeconds: 90
+  # livenessProbe.failureThreshold -- After how many subsequent failures the pod gets restarted.
+  failureThreshold: 9
+  # livenessProbe.timeoutSeconds -- Timeout of liveness probes, should roughly reflect allowed timeouts from clients.
+  timeoutSeconds: 5
 
 readinessProbe:
   # readinessProbe.enabled -- Enable readiness probes.
   enabled: true
   # readinessProbe.initialDelaySeconds -- Initial delay in seconds.
-  initialDelaySeconds: 30
+  initialDelaySeconds: 10
+  # readinessProbe.failureThreshold -- After how many tries the pod stops receiving traffic.
+  failureThreshold: 3
+
 # nodeSelector -- Define which nodes the pods are scheduled on.
 nodeSelector: {}
 # tolerations -- Tolerations for use with node [taints](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/).


### PR DESCRIPTION
## Description

* Changes liveness- and readiness probe default values
* Adds a preStop handler to give time for finishing up existing client connections/requests before shutting down. (This has the effect that shutting down pods takes longer, but it will be a clean shutdown from a user perspective, assuming there are other pods to handle the traffic)

## Motivation
Having the same failure threshold on the same endpoint URL combines the effect, resp. the readiness probe has no further value because it gets restarted anyway due to failing liveness probe.
Setting the failure threshold on the liveness probe higher than readiness gives the Pod more time to recover before restarting it with "wood hammer method".

See blogs here:
* https://freecontent.manning.com/handling-client-requests-properly-with-kubernetes/
* https://blog.colinbreck.com/kubernetes-liveness-and-readiness-probes-how-to-avoid-shooting-yourself-in-the-foot/

## Type of change
Please delete options that are irrelevant.

- [x] Bug fix (non-breaking change)
- [ ] Bug fix (breaking change, which have impact to existing functionality)
- [ ] Feature (non-breaking change)
- [x] Feature (breaking change, which have impact to existing functionality)
- [ ] Documentation

## How has this been tested?
Load test using [bombardier](https://github.com/codesenberg/bombardier):
1. Have 2 replicas of microgateway, 1 for echo backend server
1. Start the bombardier load test (command & result below)
1. While the load test runs, delete 1 microgateway pod
1. Examine results after bombardier has finished the test
1. Repeat the test, but this time with `preStop` handler, and compare results 

Result without `preStop` handler:
```
~/go/bin/bombardier -c 50 -n 300 -d 10s -k https://<host>
Bombarding https://<host>:443 with 300 request(s) using 50 connection(s)
 300 / 300 [==] 100.00% 15/s 19s
Done!
Statistics        Avg      Stdev        Max
  Reqs/sec        15.24      55.41     499.33
  Latency         3.15s      3.00s     10.01s
  HTTP codes:
    1xx - 0, 2xx - 282, 3xx - 0, 4xx - 0, 5xx - 0
    others - 18
  Errors:
    the server closed connection before returning the first response byte. Make sure the server returns 'Connection: close' response header before closing the connection - 18
  Throughput:    73.25KB/s
```
We lost about 18 requests ("others" field) out of 300, in ~20s

Result with `preStop` handler:
```
~/go/bin/bombardier -c 50 -n 300 -d 10s -k https://<host>
Bombarding https://<host>:443 with 300 request(s) using 50 connection(s)
 300 / 300 [==] 100.00% 26/s 11s
Done!
Statistics        Avg      Stdev        Max
  Reqs/sec        27.14      66.65     401.88
  Latency         1.73s   657.33ms      3.90s
  HTTP codes:
    1xx - 0, 2xx - 300, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:   117.17KB/s
```
We lost no requests here.

I understand this as follows: I assume that while starting the test, the Openshift Router distributes the load 50-50 on each microgateway pod. Upon deleting a Pod, the service will stop sending traffic to the terminating pod, but allows active requests to be finished by the microgateway/backend for 10 seconds before microgateway process actually receives SIGTERM. During that time, another Pod gets already scheduled and started, and meanwhile the remaining pod receives 100% of the traffic until the new Pod is ready.

**Versions**
* Microgateway: 1.0
* Helm Chart: 0.6.0
* Helm client: v3.1.2
* Kubernetes / Openshift: Openshift 3.11

## Checklist:
- [x] The code has been reviewed (self-review, ...).
- [ ] The parts of the code which are hard to understand are commented.
- [x] The corresponding documentation has been updated.
- [ ] The changes do not cause warnings.
- [ ] The spelling has been checked.
