### PR TITLE
Adjust resource requests and limits

### DIFF
--- a/charts/microgateway/Chart.yaml
+++ b/charts/microgateway/Chart.yaml
@@ -14,5 +14,5 @@ maintainers:
   - email: support@airlock.com
     name: Airlock
 name: microgateway
-version: 0.6.0
+version: 0.6.1
 appVersion: 1.0

--- a/charts/microgateway/README.md
+++ b/charts/microgateway/README.md
@@ -6,7 +6,7 @@ It is the lightweight, container-based deployment form of the *Airlock Gateway*,
 
 The Airlock helm charts are used internally for testing the *Airlock Microgateway*. We make them available publicly under the [MIT license](https://github.com/ergon/airlock-helm-charts/blob/master/LICENSE).
 
-The current chart version is: 0.6.0
+The current chart version is: 0.6.1
 
 ## About Ergon
 *Airlock* is a registered trademark of [Ergon](https://www.ergon.ch). Ergon is a Swiss leader in leveraging digitalisation to create unique and effective client benefits, from conception to market, the result of which is the international distribution of globally revered products.
@@ -158,7 +158,7 @@ The following table lists configuration parameters of the Airlock Microgateway c
 | redis | object | See `redis.*`: | Pre-configured [Redis](#redis) service. |
 | redis.enabled | bool | `false` | Deploy pre-configured [Redis](#redis). |
 | replicaCount | int | `1` | Desired number of Microgateway pods. |
-| resources | object | `{"limits":{"cpu":"4","memory":"4048Mi"},"requests":{"cpu":"500m","memory":"512Mi"}}` | [Resource limits](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container) |
+| resources | object | `{"limits":{"memory":"4048Mi"},"requests":{"cpu":"30m","memory":"256Mi"}}` | [Resource limits](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container) |
 | route | object | See `route.*`: | [Openshift Route](#openshift-route) |
 | route.annotations | object | `{}` | Annotations to set on the route. |
 | route.enabled | bool | `false` | Create a route object. |

--- a/charts/microgateway/values.yaml
+++ b/charts/microgateway/values.yaml
@@ -268,11 +268,10 @@ route:
 # resources -- [Resource limits](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container)
 resources:
   requests:
-    memory: "512Mi"
-    cpu: "500m"
+    memory: 256Mi
+    cpu: 30m
   limits:
-    memory: "4048Mi"
-    cpu: "4"
+    memory: 4048Mi
 
 ## Liveness and readiness probe values
 ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes


### PR DESCRIPTION
## Description

* Removes CPU limit
* Lower CPU request to 30m

## Motivation

According to K8s best practices:
* CPU limit should not be enabled unless it's a development environment
* CPU request should not be set too high, else a node might be "full" with CPU requests very fast, preventing Pod scheduling. Example: a 2-core node (2000m CPU) could not run more than 3 microgateway pods if the CPU request is 500m each (totalling 1500m, but there may be system-relevant pods also on the node). we have found `30m` to be reasonable for generic usage in our clusters.

See also https://learnk8s.io/production-best-practices

## Type of change

- [x] Bug fix (non-breaking change)
- [ ] Bug fix (breaking change, which have impact to existing functionality)
- [ ] Feature (non-breaking change)
- [ ] Feature (breaking change, which have impact to existing functionality)
- [ ] Documentation

## How has this been tested?
not tested

**Versions**
* Microgateway: 1.0
* Helm Chart: 0.6.0
* Helm client: v3.1.2
* Kubernetes / Openshift: irrelevant

## Checklist:
- [x] The code has been reviewed (self-review, ...).
- [ ] The parts of the code which are hard to understand are commented.
- [x] The corresponding documentation has been updated.
- [ ] The changes do not cause warnings.
- [ ] The spelling has been checked.
