### PR TITLE
Remove reference to base_template_file configuration parameter.

### DIFF
--- a/charts/microgateway/Chart.yaml
+++ b/charts/microgateway/Chart.yaml
@@ -14,5 +14,5 @@ maintainers:
   - email: support@airlock.com
     name: Airlock
 name: microgateway
-version: 0.6.1
+version: 0.6.2
 appVersion: 1.0

--- a/charts/microgateway/README.md
+++ b/charts/microgateway/README.md
@@ -445,7 +445,7 @@ The use cases outlined above can also occur slightly differently. But all of the
 ### Expert DSL configuration
 In case that the [Advanced DSL configuration](#advanced-dsl-configuration) does not suite, the expert configuration options must be used. There are a few reasons listed below:
 
-* The Microgateway DSL configuration options are not available as Helm chart parameters (e.g. base_template_file, session.store_mode, ...)
+* The Microgateway DSL configuration options are not available as Helm chart parameters (e.g. session.store_mode, ...)
 * The Microgateway DSL configuration file has already been used/tested thorougly. To reduce the risk of a broken or unsecure configuration, do not modify the pre-configured configuration file.
 
 
@@ -456,7 +456,6 @@ In case that the [Advanced DSL configuration](#advanced-dsl-configuration) does 
   config:
     expert:
       dsl:
-        base_template_file: /config/custom-base.xml
         license_file: /secret/config/license
         session:
           encryption_passphrase_file: /secret/config/passphrase

--- a/charts/microgateway/README.md
+++ b/charts/microgateway/README.md
@@ -6,7 +6,7 @@ It is the lightweight, container-based deployment form of the *Airlock Gateway*,
 
 The Airlock helm charts are used internally for testing the *Airlock Microgateway*. We make them available publicly under the [MIT license](https://github.com/ergon/airlock-helm-charts/blob/master/LICENSE).
 
-The current chart version is: 0.6.1
+The current chart version is: 0.6.2
 
 ## About Ergon
 *Airlock* is a registered trademark of [Ergon](https://www.ergon.ch). Ergon is a Swiss leader in leveraging digitalisation to create unique and effective client benefits, from conception to market, the result of which is the international distribution of globally revered products.

--- a/charts/microgateway/README.md.gotmpl
+++ b/charts/microgateway/README.md.gotmpl
@@ -346,7 +346,7 @@ The use cases outlined above can also occur slightly differently. But all of the
 ### Expert DSL configuration
 In case that the [Advanced DSL configuration](#advanced-dsl-configuration) does not suite, the expert configuration options must be used. There are a few reasons listed below:
 
-* The Microgateway DSL configuration options are not available as Helm chart parameters (e.g. base_template_file, session.store_mode, ...)
+* The Microgateway DSL configuration options are not available as Helm chart parameters (e.g. session.store_mode, ...)
 * The Microgateway DSL configuration file has already been used/tested thorougly. To reduce the risk of a broken or unsecure configuration, do not modify the pre-configured configuration file.
 
 
@@ -357,7 +357,6 @@ In case that the [Advanced DSL configuration](#advanced-dsl-configuration) does 
   config:
     expert:
       dsl:
-        base_template_file: /config/custom-base.xml
         license_file: /secret/config/license
         session:
           encryption_passphrase_file: /secret/config/passphrase


### PR DESCRIPTION
Microgateway configuration using the base_template_file configuration paramater is no longer supported.

# Pull Request Template

## Type of change
Please delete options that are irrelevant.
- [x ] Documentation

**Versions**
* Microgateway: 1.0
* Helm Chart: 0.6.1

## Checklist:
- [x] The code has been reviewed (self-review, ...).
- [ ] The parts of the code which are hard to understand are commented.
- [ ] The corresponding documentation has been updated.
- [ ] The changes do not cause warnings.
- [ ] The spelling has been checked.
