### PR TITLE
create config using the 2.0 init container.

### DIFF
--- a/charts/microgateway/Chart.yaml
+++ b/charts/microgateway/Chart.yaml
@@ -14,5 +14,5 @@ maintainers:
   - email: support@airlock.com
     name: Airlock
 name: microgateway
-version: 0.6.1
-appVersion: 1.0
+version: 0.7.0
+appVersion: 2.0

--- a/charts/microgateway/README.md
+++ b/charts/microgateway/README.md
@@ -424,9 +424,9 @@ The use cases outlined above can also occur slightly differently. But all of the
                       pattern: ^POST$
               backend:
                 hosts:
-                  protocol: https
-                  name: custom-backend-service
-                  port: 8443
+                  - protocol: https
+                    name: custom-backend-service
+                    port: 8443
             - name: api
               entry_path: /api/
               session_handling: ignore_session
@@ -489,9 +489,9 @@ In case that the [Advanced DSL configuration](#advanced-dsl-configuration) does 
                   spec_file: /config/virtinc_api_openapi.json
                 backend:
                   hosts:
-                    protocol: https
-                    name: custom-backend-service
-                    port: 8443
+                    - protocol: https
+                      name: custom-backend-service
+                      port: 8443
 
   redis:
     enabled: true

--- a/charts/microgateway/README.md
+++ b/charts/microgateway/README.md
@@ -436,9 +436,9 @@ The use cases outlined above can also occur slightly differently. But all of the
                 spec_file: /config/virtinc_api_openapi.json
               backend:
                 hosts:
-                  protocol: https
-                  name: custom-backend-service
-                  port: 8443
+                  - protocol: https
+                    name: custom-backend-service
+                    port: 8443
 
   redis:
     enabled: true

--- a/charts/microgateway/README.md
+++ b/charts/microgateway/README.md
@@ -115,9 +115,6 @@ The following table lists configuration parameters of the Airlock Microgateway c
 | config.global.virtual_host.tls.cipher_suite | string | `""` | Overwrite the default TLS ciphers for frontend connections. |
 | config.global.virtual_host.tls.protocol | string | `""` | Overwrite the default TLS protocol for frontend connections. |
 | config.simple | object | See `config.simple.*`: | [Simple DSL configuration](#simple-dsl-configuration) |
-| config.simple.backend.hostname | string | `"backend-service"` | Backend hostname |
-| config.simple.backend.port | int | `8080` | Backend port |
-| config.simple.backend.protocol | string | `"http"` | Backend protocol |
 | config.simple.mapping.deny_rules.enabled | bool | `true` | Enable all Deny rules. |
 | config.simple.mapping.deny_rules.exceptions | list | `[]` | Deny rule exceptions. |
 | config.simple.mapping.deny_rules.level | string | `"standard"` | Security Level for all Deny rules (`basic`, `standard`, `strict`). |
@@ -243,8 +240,9 @@ The Airlock Microgateway Helm chart has many parameters and most of them are alr
   ```
   config:
     simple:
-      backend:
-        hostname: custom-backend-service
+      mapping:
+        backend:
+          hostname: custom-backend-service
     generic:
       existingSecret: "microgateway-secrets"
   imagePullSecrets:
@@ -358,10 +356,10 @@ By default, the Airlock Microgateway is configured with the [Simple DSL configur
                 pattern: ^/mail/
               method:
                 pattern: ^POST$
-      backend:
-        protocol: https
-        hostname: custom-backend-service
-        port: 8443
+        backend:
+          protocol: https
+          hostname: custom-backend-service
+          port: 8443
 
   redis:
     enabled: true

--- a/charts/microgateway/README.md
+++ b/charts/microgateway/README.md
@@ -115,6 +115,9 @@ The following table lists configuration parameters of the Airlock Microgateway c
 | config.global.virtual_host.tls.cipher_suite | string | `""` | Overwrite the default TLS ciphers for frontend connections. |
 | config.global.virtual_host.tls.protocol | string | `""` | Overwrite the default TLS protocol for frontend connections. |
 | config.simple | object | See `config.simple.*`: | [Simple DSL configuration](#simple-dsl-configuration) |
+| config.simple.backend.hostname | string | `"backend-service"` | Backend hostname |
+| config.simple.backend.port | int | `8080` | Backend port |
+| config.simple.backend.protocol | string | `"http"` | Backend protocol |
 | config.simple.mapping.deny_rules.enabled | bool | `true` | Enable all Deny rules. |
 | config.simple.mapping.deny_rules.exceptions | list | `[]` | Deny rule exceptions. |
 | config.simple.mapping.deny_rules.level | string | `"standard"` | Security Level for all Deny rules (`basic`, `standard`, `strict`). |
@@ -240,9 +243,8 @@ The Airlock Microgateway Helm chart has many parameters and most of them are alr
   ```
   config:
     simple:
-      mapping:
-        backend:
-          hostname: custom-backend-service
+      backend:
+        hostname: custom-backend-service
     generic:
       existingSecret: "microgateway-secrets"
   imagePullSecrets:
@@ -356,10 +358,10 @@ By default, the Airlock Microgateway is configured with the [Simple DSL configur
                 pattern: ^/mail/
               method:
                 pattern: ^POST$
-        backend:
-          protocol: https
-          hostname: custom-backend-service
-          port: 8443
+      backend:
+        protocol: https
+        hostname: custom-backend-service
+        port: 8443
 
   redis:
     enabled: true
@@ -420,6 +422,11 @@ The use cases outlined above can also occur slightly differently. But all of the
                       pattern: ^/mail/
                     method:
                       pattern: ^POST$
+              backend:
+                hosts:
+                  protocol: https
+                  name: custom-backend-service
+                  port: 8443
             - name: api
               entry_path: /api/
               session_handling: ignore_session
@@ -427,10 +434,11 @@ The use cases outlined above can also occur slightly differently. But all of the
                 - level: strict
               openapi:
                 spec_file: /config/virtinc_api_openapi.json
-          backend:
-            protocol: https
-            hostname: custom-backend-service
-            port: 8443
+              backend:
+                hosts:
+                  protocol: https
+                  name: custom-backend-service
+                  port: 8443
 
   redis:
     enabled: true
@@ -479,10 +487,11 @@ In case that the [Advanced DSL configuration](#advanced-dsl-configuration) does 
                 session_handling: ignore_session
                 openapi:
                   spec_file: /config/virtinc_api_openapi.json
-            backend:
-              protocol: https
-              hostname: custom-backend-service
-              port: 8443
+                backend:
+                  hosts:
+                    protocol: https
+                    name: custom-backend-service
+                    port: 8443
 
   redis:
     enabled: true

--- a/charts/microgateway/README.md
+++ b/charts/microgateway/README.md
@@ -6,7 +6,7 @@ It is the lightweight, container-based deployment form of the *Airlock Gateway*,
 
 The Airlock helm charts are used internally for testing the *Airlock Microgateway*. We make them available publicly under the [MIT license](https://github.com/ergon/airlock-helm-charts/blob/master/LICENSE).
 
-The current chart version is: 0.6.2
+The current chart version is: 0.7.0
 
 ## About Ergon
 *Airlock* is a registered trademark of [Ergon](https://www.ergon.ch). Ergon is a Swiss leader in leveraging digitalisation to create unique and effective client benefits, from conception to market, the result of which is the international distribution of globally revered products.
@@ -137,8 +137,9 @@ The following table lists configuration parameters of the Airlock Microgateway c
 | hpa.resource.cpu | int | `50` | Average Microgateway CPU consumption in percentage to scale up/down. |
 | hpa.resource.memory | string | `"2Gi"` | Average Microgateway Memory consumption to scale up/down.<br><br> :exclamation: Update this setting accordingly to `resources.limits.memory`. |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy (`Always`, `IfNotPresent`, `Never`) |
-| image.repository | string | `"ergon/airlock-microgateway"` | Image repository |
-| image.tag | string | `"1.0"` | Image tag |
+| image.repository | string | `"ergon/airlock-microgateway"` | Image repository for the Airlock Microgateway runtime image |
+| image.repository_configbuilder | string | `"ergon/airlock-microgateway-configbuilder"` | Image repository for the Airlock Microgateway configbuilder image |
+| image.tag | string | `"2.0"` | Image tag for runtime and config builder image |
 | imagePullSecrets | list | `[]` | Reference to one or more secrets to use when pulling images. |
 | ingress | object | See `ingress.*`: | [Kubernetes Ingress](#kubernetes-ingress) |
 | ingress.annotations | object | `{"nginx.ingress.kubernetes.io/rewrite-target":"/"}` | Annotations to set on the ingress. |

--- a/charts/microgateway/README.md.gotmpl
+++ b/charts/microgateway/README.md.gotmpl
@@ -324,9 +324,9 @@ The use cases outlined above can also occur slightly differently. But all of the
                       pattern: ^POST$
               backend:
                 hosts:
-                  protocol: https
-                  name: custom-backend-service
-                  port: 8443
+                  - protocol: https
+                    name: custom-backend-service
+                    port: 8443
             - name: api
               entry_path: /api/
               session_handling: ignore_session
@@ -389,9 +389,9 @@ In case that the [Advanced DSL configuration](#advanced-dsl-configuration) does 
                   spec_file: /config/virtinc_api_openapi.json
                 backend:
                   hosts:
-                    protocol: https
-                    name: custom-backend-service
-                    port: 8443
+                    - protocol: https
+                      name: custom-backend-service
+                      port: 8443
 
   redis:
     enabled: true

--- a/charts/microgateway/README.md.gotmpl
+++ b/charts/microgateway/README.md.gotmpl
@@ -146,8 +146,9 @@ The Airlock Microgateway Helm chart has many parameters and most of them are alr
   ```
   config:
     simple:
-      backend:
-        hostname: custom-backend-service
+      mapping:
+        backend:
+          hostname: custom-backend-service
     generic:
       existingSecret: "microgateway-secrets"
   imagePullSecrets:
@@ -258,10 +259,10 @@ By default, the Airlock Microgateway is configured with the [Simple DSL configur
                 pattern: ^/mail/
               method:
                 pattern: ^POST$
-      backend:
-        protocol: https
-        hostname: custom-backend-service
-        port: 8443
+        backend:
+          protocol: https
+          hostname: custom-backend-service
+          port: 8443
 
   redis:
     enabled: true

--- a/charts/microgateway/README.md.gotmpl
+++ b/charts/microgateway/README.md.gotmpl
@@ -336,9 +336,9 @@ The use cases outlined above can also occur slightly differently. But all of the
                 spec_file: /config/virtinc_api_openapi.json
               backend:
                 hosts:
-                  protocol: https
-                  name: custom-backend-service
-                  port: 8443
+                  - protocol: https
+                    name: custom-backend-service
+                    port: 8443
 
   redis:
     enabled: true

--- a/charts/microgateway/README.md.gotmpl
+++ b/charts/microgateway/README.md.gotmpl
@@ -146,9 +146,8 @@ The Airlock Microgateway Helm chart has many parameters and most of them are alr
   ```
   config:
     simple:
-      mapping:
-        backend:
-          hostname: custom-backend-service
+      backend:
+        hostname: custom-backend-service
     generic:
       existingSecret: "microgateway-secrets"
   imagePullSecrets:
@@ -259,10 +258,10 @@ By default, the Airlock Microgateway is configured with the [Simple DSL configur
                 pattern: ^/mail/
               method:
                 pattern: ^POST$
-        backend:
-          protocol: https
-          hostname: custom-backend-service
-          port: 8443
+      backend:
+        protocol: https
+        hostname: custom-backend-service
+        port: 8443
 
   redis:
     enabled: true
@@ -323,6 +322,11 @@ The use cases outlined above can also occur slightly differently. But all of the
                       pattern: ^/mail/
                     method:
                       pattern: ^POST$
+              backend:
+                hosts:
+                  protocol: https
+                  name: custom-backend-service
+                  port: 8443
             - name: api
               entry_path: /api/
               session_handling: ignore_session
@@ -330,10 +334,11 @@ The use cases outlined above can also occur slightly differently. But all of the
                 - level: strict
               openapi:
                 spec_file: /config/virtinc_api_openapi.json
-          backend:
-            protocol: https
-            hostname: custom-backend-service
-            port: 8443
+              backend:
+                hosts:
+                  protocol: https
+                  name: custom-backend-service
+                  port: 8443
 
   redis:
     enabled: true
@@ -382,10 +387,11 @@ In case that the [Advanced DSL configuration](#advanced-dsl-configuration) does 
                 session_handling: ignore_session
                 openapi:
                   spec_file: /config/virtinc_api_openapi.json
-            backend:
-              protocol: https
-              hostname: custom-backend-service
-              port: 8443
+                backend:
+                  hosts:
+                    protocol: https
+                    name: custom-backend-service
+                    port: 8443
 
   redis:
     enabled: true

--- a/charts/microgateway/templates/configmap.yaml
+++ b/charts/microgateway/templates/configmap.yaml
@@ -96,9 +96,9 @@ data:
           {{- end }}
         backend:
           hosts:
-          - protocol: {{ $simple.mapping.backend.protocol }}
-            name: {{ $simple.mapping.backend.hostname }}
-            port: {{ $simple.mapping.backend.port }}
+          - protocol: {{ $simple.backend.protocol }}
+            name: {{ $simple.backend.hostname }}
+            port: {{ $simple.backend.port }}
     {{- if $generic.tlsSecretName }}
       virtual_host:
         certificate:

--- a/charts/microgateway/templates/configmap.yaml
+++ b/charts/microgateway/templates/configmap.yaml
@@ -95,9 +95,10 @@ data:
           exceptions: {{ toYaml . | nindent 12 }}
           {{- end }}
         backend:
-          protocol: {{ $simple.backend.protocol }}
-          hostname: {{ $simple.backend.hostname }}
-          port: {{ $simple.backend.port }}
+          hosts:
+          - protocol: {{ $simple.mapping.backend.protocol }}
+            name: {{ $simple.mapping.backend.hostname }}
+            port: {{ $simple.mapping.backend.port }}
     {{- if $generic.tlsSecretName }}
       virtual_host:
         certificate:

--- a/charts/microgateway/templates/configmap.yaml
+++ b/charts/microgateway/templates/configmap.yaml
@@ -87,17 +87,17 @@ data:
         {{- else }}
         session_handling: {{ "ignore_session" }}
         {{- end }}
-        deny_rules:
+        deny_rule_groups:
         - enabled: {{ $simple.mapping.deny_rules.enabled }}
           log_only: {{ $simple.mapping.deny_rules.log_only }}
           level: {{ $simple.mapping.deny_rules.level }}
           {{- with $simple.mapping.deny_rules.exceptions }}
           exceptions: {{ toYaml . | nindent 12 }}
           {{- end }}
-      backend:
-        protocol: {{ $simple.backend.protocol }}
-        hostname: {{ $simple.backend.hostname }}
-        port: {{ $simple.backend.port }}
+        backend:
+          protocol: {{ $simple.backend.protocol }}
+          hostname: {{ $simple.backend.hostname }}
+          port: {{ $simple.backend.port }}
     {{- if $generic.tlsSecretName }}
       virtual_host:
         certificate:

--- a/charts/microgateway/templates/deployment.yaml
+++ b/charts/microgateway/templates/deployment.yaml
@@ -25,18 +25,10 @@ spec:
     {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      containers:
-      - name: {{ .Chart.Name }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+      initContainers:
+      - name: {{ .Chart.Name }}-configbuilder
+        image: "{{ .Values.image.repository_configbuilder }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        ports:
-        - name: http
-          containerPort: 8080
-        - name: https
-          containerPort: 8443
-        {{- with .Values.config.generic.env }}
-        env: {{ toYaml . | nindent 10 }}
-        {{- end }}
         volumeMounts:
         - name: config
           mountPath: /config/config.yaml
@@ -53,6 +45,24 @@ spec:
         {{- with .Values.extraVolumeMounts }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
+        - name: config-files
+          mountPath: /resources-gen
+
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - name: http
+          containerPort: 8080
+        - name: https
+          containerPort: 8443
+        {{- with .Values.config.generic.env }}
+        env: {{ toYaml . | nindent 10 }}
+        {{- end }}
+        volumeMounts:
+        - name: config-files
+          mountPath: /config/
         {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
           failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
@@ -92,6 +102,8 @@ spec:
         secret:
           secretName: {{ . }}
       {{- end }}
+      - name: config-files
+        emptyDir: {}
       {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 6 }}
       {{- end }}

--- a/charts/microgateway/values.yaml
+++ b/charts/microgateway/values.yaml
@@ -38,13 +38,13 @@ config:
         #     pattern: (PCRE Pattern-String)
         #     ignore_case: (default: TRUE)
         #     inverted: (default: FALSE)
-    backend:
-      # config.simple.backend.hostname -- Backend hostname
-      hostname: backend-service
-      # config.simple.backend.port -- Backend port
-      port: 8080
-      # config.simple.backend.protocol -- Backend protocol
-      protocol: http
+      backend:
+        # config.simple.backend.hostname -- Backend hostname
+        hostname: backend-service
+        # config.simple.backend.port -- Backend port
+        port: 8080
+        # config.simple.backend.protocol -- Backend protocol
+        protocol: http
 
   # config.global -- Available for:<br>
   # - [Simple DSL configuration](#simple-dsl-configuration)<br>

--- a/charts/microgateway/values.yaml
+++ b/charts/microgateway/values.yaml
@@ -38,13 +38,13 @@ config:
         #     pattern: (PCRE Pattern-String)
         #     ignore_case: (default: TRUE)
         #     inverted: (default: FALSE)
-      backend:
-        # config.simple.backend.hostname -- Backend hostname
-        hostname: backend-service
-        # config.simple.backend.port -- Backend port
-        port: 8080
-        # config.simple.backend.protocol -- Backend protocol
-        protocol: http
+    backend:
+      # config.simple.backend.hostname -- Backend hostname
+      hostname: backend-service
+      # config.simple.backend.port -- Backend port
+      port: 8080
+      # config.simple.backend.protocol -- Backend protocol
+      protocol: http
 
   # config.global -- Available for:<br>
   # - [Simple DSL configuration](#simple-dsl-configuration)<br>

--- a/charts/microgateway/values.yaml
+++ b/charts/microgateway/values.yaml
@@ -2,10 +2,12 @@
 replicaCount: 1
 
 image:
-  # image.repository -- Image repository
+  # image.repository -- Image repository for the Airlock Microgateway runtime image
   repository: ergon/airlock-microgateway
-  # image.tag -- Image tag
-  tag: "1.0"
+  # image.repository_configbuilder -- Image repository for the Airlock Microgateway configbuilder image
+  repository_configbuilder: ergon/airlock-microgateway-configbuilder
+  # image.tag -- Image tag for runtime and config builder image
+  tag: "2.0"
   # image.pullPolicy -- Pull policy (`Always`, `IfNotPresent`, `Never`)
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
# Pull Request Template

## Description

Change the deployment to use an init container to create the microgateway config.

Adaptions to additional changes in the DSL in 2.0 have been included in this PR to make the helm chart configuration work again:
- renaming deny_rules -> deny_rule_groups
- backend is now a leaf of mapping
- backends may have more than one host

## Motivation
The configuration paradigm of the microgatway changes with version 2.0. The helm chart has to reflect these changes.

## Type of change
Please delete options that are irrelevant.

- [x] Bug fix (non-breaking change)
- [x] Documentation

## How has this been tested?
Deployment into a minishift cluster

**Versions**
* Microgateway: 2.0
* Helm Chart: 0.7.0


## Checklist:
- [x] The code has been reviewed (self-review, ...).
- [ ] The parts of the code which are hard to understand are commented.
- [x] The corresponding documentation has been updated.
- [ ] The changes do not cause warnings.
- [ ] The spelling has been checked.
