### PR TITLE
set separate env variables for configbuilder and runtime image

### DIFF
--- a/charts/microgateway/README.md
+++ b/charts/microgateway/README.md
@@ -94,10 +94,11 @@ The following table lists configuration parameters of the Airlock Microgateway c
 | config.advanced.apps | list | `[]` | [Advanced DSL configuration](#advanced-dsl-configuration) |
 | config.expert.dsl | object | `{}` | [Expert DSL configuration](#expert-dsl-configuration) |
 | config.generic | object | See `config.generic.*`: | Available for:<br> - [Simple DSL configuration](#simple-dsl-configuration)<br> - [Advanced DSL configuration](#advanced-dsl-configuration)<br> - [Expert DSL configuration](#expert-dsl-configuration) |
-| config.generic.env | list | `[]` | [Environment variables](#environment-variables) |
+| config.generic.configEnv | list | `[]` | [Environment variables used in variable substitution in the microgateway config](#environment-variables)  - name: ALG_CFG_EXAMPLE    value: Example_Value |
 | config.generic.existingSecret | string | "" | Name of an existing secret containing:<br><br> license: `license`<br> passphrase: `passphrase` |
 | config.generic.license | string | "" | License (multiline string) |
 | config.generic.passphrase | string | - `passphrase`<br> If `passphrase` in `config.generic.existingSecret` <br><br> - `<generated passphrase>`<br> If no passphrase available. | Passphrase used for encryption. |
+| config.generic.runtimeEnv | list | `[]` | [Environment variables injected into the microgateway runtime container](#environment-variables) |
 | config.generic.tlsSecretName | string | "" | Name of an existing secret containing:<br><br> _Virtual Host:_<br> Certificate: `frontend-server.crt`<br> Private key: `frontend-server.key`<br> CA: `frontend-server-ca.crt` <br> :exclamation: Update `route.tls.destinationCACertificate` accordingly.<br><br> _Backend:_<br> Certificate: `backend-client.crt`<br> Private key: `backend-client.key`<br> CA: `backend-server-validation-ca.crt` |
 | config.global | object | See `config.global.*`: | Available for:<br> - [Simple DSL configuration](#simple-dsl-configuration)<br> - [Advanced DSL configuration](#advanced-dsl-configuration) |
 | config.global.backend.tls.cipher_suite | string | `""` | Overwrite the default TLS ciphers (<=TLS 1.2) for backend connections. |
@@ -504,7 +505,8 @@ In case that the [Advanced DSL configuration](#advanced-dsl-configuration) does 
 * `config.expert.dsl - **must** be used.
 * `config.generic.*`
 
-## Environment variables
+## Environment Variables
+### Using Environment Variables in the DSL Configuration
 Environment variables can be configured with the Helm chart and used within the [DSL Configuration](#dsl-configuration).
 This works for all three DSL of the above configuration setups (simple, advanced and expert). The example below illustrates how to configure environment variables in combination with the [Simple DSL configuration](#simple-dsl-configuration).
 
@@ -512,7 +514,7 @@ This works for all three DSL of the above configuration setups (simple, advanced
   ```
   config:
     generic:
-      env:
+      configEnv:
         - name: ALG_CFG_OPERATIONAL_MODE
           value: production
         - name: ALG_CFG_LOG_ONLY
@@ -534,6 +536,19 @@ Finally, apply the Helm chart configuration file with `-f` parameter.
   ```console
   helm upgrade -i microgateway airlock/microgateway -f custom-values.yaml -f env-variables.yaml
   ```
+
+### Setting Environment Variables for the Runtime Container
+The Helm chart also allows to specify environment variables for the runtime container.
+The following example shows how to set the timezone of the microgateway:
+
+env-variables.yaml
+```
+config:
+  generic:
+    runtimeEnv:
+      - name: TZ
+        value: Europe/Zurich
+```
 
 ## Extra Volumes
 The Helm chart allows you to define extra volumes which can be used in the Microgateway.

--- a/charts/microgateway/README.md
+++ b/charts/microgateway/README.md
@@ -29,7 +29,9 @@ The current chart version is: 0.7.0
   * [Simple DSL configuration](#simple-dsl-configuration)
   * [Advanced DSL configuration](#advanced-dsl-configuration)
   * [Expert DSL configuration](#expert-dsl-configuration)
-* [Environment variables](#environment-variables)
+* [Environment Variables](#environment-variables)
+  * [DSL Environment Variables](#dsl-environment-variables)
+  * [Runtime Environment Variables](#runtime-environment-variables)
 * [Extra Volumes](#extra-volumes)
 * [Probes](#probes)
   * [Readiness Probe](#readiness-probe)
@@ -94,11 +96,11 @@ The following table lists configuration parameters of the Airlock Microgateway c
 | config.advanced.apps | list | `[]` | [Advanced DSL configuration](#advanced-dsl-configuration) |
 | config.expert.dsl | object | `{}` | [Expert DSL configuration](#expert-dsl-configuration) |
 | config.generic | object | See `config.generic.*`: | Available for:<br> - [Simple DSL configuration](#simple-dsl-configuration)<br> - [Advanced DSL configuration](#advanced-dsl-configuration)<br> - [Expert DSL configuration](#expert-dsl-configuration) |
-| config.generic.configEnv | list | `[]` | [Environment variables used in variable substitution in the microgateway config](#environment-variables)  - name: ALG_CFG_EXAMPLE    value: Example_Value |
+| config.generic.configEnv | list | `[]` | [DSL Environment Variables](#dsl-environment-variables) |
 | config.generic.existingSecret | string | "" | Name of an existing secret containing:<br><br> license: `license`<br> passphrase: `passphrase` |
 | config.generic.license | string | "" | License (multiline string) |
 | config.generic.passphrase | string | - `passphrase`<br> If `passphrase` in `config.generic.existingSecret` <br><br> - `<generated passphrase>`<br> If no passphrase available. | Passphrase used for encryption. |
-| config.generic.runtimeEnv | list | `[]` | [Environment variables injected into the microgateway runtime container](#environment-variables) |
+| config.generic.runtimeEnv | list | `[]` | [Runtime Environment Variables](#runtime-environment-variables) |
 | config.generic.tlsSecretName | string | "" | Name of an existing secret containing:<br><br> _Virtual Host:_<br> Certificate: `frontend-server.crt`<br> Private key: `frontend-server.key`<br> CA: `frontend-server-ca.crt` <br> :exclamation: Update `route.tls.destinationCACertificate` accordingly.<br><br> _Backend:_<br> Certificate: `backend-client.crt`<br> Private key: `backend-client.key`<br> CA: `backend-server-validation-ca.crt` |
 | config.global | object | See `config.global.*`: | Available for:<br> - [Simple DSL configuration](#simple-dsl-configuration)<br> - [Advanced DSL configuration](#advanced-dsl-configuration) |
 | config.global.backend.tls.cipher_suite | string | `""` | Overwrite the default TLS ciphers (<=TLS 1.2) for backend connections. |
@@ -506,7 +508,7 @@ In case that the [Advanced DSL configuration](#advanced-dsl-configuration) does 
 * `config.generic.*`
 
 ## Environment Variables
-### Using Environment Variables in the DSL Configuration
+### DSL Environment Variables
 Environment variables can be configured with the Helm chart and used within the [DSL Configuration](#dsl-configuration).
 This works for all three DSL of the above configuration setups (simple, advanced and expert). The example below illustrates how to configure environment variables in combination with the [Simple DSL configuration](#simple-dsl-configuration).
 
@@ -537,7 +539,7 @@ Finally, apply the Helm chart configuration file with `-f` parameter.
   helm upgrade -i microgateway airlock/microgateway -f custom-values.yaml -f env-variables.yaml
   ```
 
-### Setting Environment Variables for the Runtime Container
+### Runtime Environment Variables
 The Helm chart also allows to specify environment variables for the runtime container.
 The following example shows how to set the timezone of the microgateway:
 

--- a/charts/microgateway/README.md.gotmpl
+++ b/charts/microgateway/README.md.gotmpl
@@ -27,7 +27,9 @@ The current chart version is: {{ template "chart.version" . }}
   * [Simple DSL configuration](#simple-dsl-configuration)
   * [Advanced DSL configuration](#advanced-dsl-configuration)
   * [Expert DSL configuration](#expert-dsl-configuration)
-* [Environment variables](#environment-variables)
+* [Environment Variables](#environment-variables)
+  * [DSL Environment Variables](#dsl-environment-variables)
+  * [Runtime Environment Variables](#runtime-environment-variables)
 * [Extra Volumes](#extra-volumes)
 * [Probes](#probes)
   * [Readiness Probe](#readiness-probe)
@@ -405,7 +407,7 @@ In case that the [Advanced DSL configuration](#advanced-dsl-configuration) does 
 * `config.generic.*`
 
 ## Environment Variables
-### Using Environment Variables in the DSL Configuration
+### DSL Environment Variables
 Environment variables can be configured with the Helm chart and used within the [DSL Configuration](#dsl-configuration).
 This works for all three DSL of the above configuration setups (simple, advanced and expert). The example below illustrates how to configure environment variables in combination with the [Simple DSL configuration](#simple-dsl-configuration).
 
@@ -436,7 +438,7 @@ Finally, apply the Helm chart configuration file with `-f` parameter.
   helm upgrade -i microgateway airlock/microgateway -f custom-values.yaml -f env-variables.yaml
   ```
 
-### Setting Environment Variables for the Runtime Container
+### Runtime Environment Variables
 The Helm chart also allows to specify environment variables for the runtime container.
 The following example shows how to set the timezone of the microgateway:
 

--- a/charts/microgateway/README.md.gotmpl
+++ b/charts/microgateway/README.md.gotmpl
@@ -404,7 +404,8 @@ In case that the [Advanced DSL configuration](#advanced-dsl-configuration) does 
 * `config.expert.dsl - **must** be used.
 * `config.generic.*`
 
-## Environment variables
+## Environment Variables
+### Using Environment Variables in the DSL Configuration
 Environment variables can be configured with the Helm chart and used within the [DSL Configuration](#dsl-configuration).
 This works for all three DSL of the above configuration setups (simple, advanced and expert). The example below illustrates how to configure environment variables in combination with the [Simple DSL configuration](#simple-dsl-configuration).
 
@@ -412,7 +413,7 @@ This works for all three DSL of the above configuration setups (simple, advanced
   ```
   config:
     generic:
-      env:
+      configEnv:
         - name: ALG_CFG_OPERATIONAL_MODE
           value: production
         - name: ALG_CFG_LOG_ONLY
@@ -434,6 +435,19 @@ Finally, apply the Helm chart configuration file with `-f` parameter.
   ```console
   helm upgrade -i microgateway airlock/microgateway -f custom-values.yaml -f env-variables.yaml
   ```
+
+### Setting Environment Variables for the Runtime Container
+The Helm chart also allows to specify environment variables for the runtime container.
+The following example shows how to set the timezone of the microgateway:
+
+env-variables.yaml
+```
+config:
+  generic:
+    runtimeEnv:
+      - name: TZ
+        value: Europe/Zurich
+```
 
 ## Extra Volumes
 The Helm chart allows you to define extra volumes which can be used in the Microgateway.

--- a/charts/microgateway/templates/NOTES.txt
+++ b/charts/microgateway/templates/NOTES.txt
@@ -32,8 +32,8 @@ The Airlock microgateway has been installed.
     ###############################################################################
 {{- end }}
 
-* ConfigMap: 
-  To see the Microgateway DSL run the follwing command: 
+* ConfigMap:
+  To see the Microgateway DSL run the follwing command:
   kubectl describe configmap {{ template "microgateway.fullname" . }}
 
 * Microgateway Pods:
@@ -44,6 +44,11 @@ The Airlock microgateway has been installed.
   To see the Microgateway Logs of a Pod run the following commands:
   export MICROGATEWAYPOD=$(kubectl get pods --selector app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/name={{ include "microgateway.name" . }} | grep {{ template "microgateway.fullname" . }} | head -1 | cut -d ' ' -f 1)
   kubectl logs $MICROGATEWAYPOD -f
+
+* Microgateway Init Container Logs:
+  To see the logs of the init container run the following commands:
+  export MICROGATEWAYPOD=$(kubectl get pods --selector app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/name={{ include "microgateway.name" . }} | grep {{ template "microgateway.fullname" . }} | head -1 | cut -d ' ' -f 1)
+  kubectl logs $MICROGATEWAYPOD -c {{ .Chart.Name }}-configbuilder
 
 * Microgateway Console:
   To connect to the console of the Microgateway run the follwing commands:

--- a/charts/microgateway/templates/deployment.yaml
+++ b/charts/microgateway/templates/deployment.yaml
@@ -29,6 +29,9 @@ spec:
       - name: {{ .Chart.Name }}-configbuilder
         image: "{{ .Values.image.repository_configbuilder }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- with .Values.config.generic.configEnv }}
+        env: {{ toYaml . | nindent 10 }}
+        {{- end }}
         volumeMounts:
         - name: config
           mountPath: /config/config.yaml
@@ -57,7 +60,7 @@ spec:
           containerPort: 8080
         - name: https
           containerPort: 8443
-        {{- with .Values.config.generic.env }}
+        {{- with .Values.config.generic.runtimeEnv }}
         env: {{ toYaml . | nindent 10 }}
         {{- end }}
         volumeMounts:

--- a/charts/microgateway/values.yaml
+++ b/charts/microgateway/values.yaml
@@ -102,10 +102,12 @@ config:
   # - [Expert DSL configuration](#expert-dsl-configuration)
   # @default -- See `config.generic.*`:
   generic:
-    # config.generic.env -- [Environment variables](#environment-variables)
-    env: []
+    # config.generic.configEnv -- [Environment variables used in variable substitution in the microgateway config](#environment-variables)
     #  - name: ALG_CFG_EXAMPLE
     #    value: Example_Value
+    configEnv: []
+    # config.generic.runtimeEnv -- [Environment variables injected into the microgateway runtime container](#environment-variables)
+    runtimeEnv: []
     # config.generic.tlsSecretName -- (string) Name of an existing secret containing:<br><br>
     # _Virtual Host:_<br>
     # Certificate: `frontend-server.crt`<br>

--- a/charts/microgateway/values.yaml
+++ b/charts/microgateway/values.yaml
@@ -102,11 +102,9 @@ config:
   # - [Expert DSL configuration](#expert-dsl-configuration)
   # @default -- See `config.generic.*`:
   generic:
-    # config.generic.configEnv -- [Environment variables used in variable substitution in the microgateway config](#environment-variables)
-    #  - name: ALG_CFG_EXAMPLE
-    #    value: Example_Value
+    # config.generic.configEnv -- [DSL Environment Variables](#dsl-environment-variables)
     configEnv: []
-    # config.generic.runtimeEnv -- [Environment variables injected into the microgateway runtime container](#environment-variables)
+    # config.generic.runtimeEnv -- [Runtime Environment Variables](#runtime-environment-variables)
     runtimeEnv: []
     # config.generic.tlsSecretName -- (string) Name of an existing secret containing:<br><br>
     # _Virtual Host:_<br>


### PR DESCRIPTION
# Pull Request Template

## Description

Use separate set of environment variables for the configbuilder and runtime container.
- configbuilder: config.generic.configEnv
- runtime: config.generic.runtimeEnv


## Type of change
Please delete options that are irrelevant.

- [x] Bug fix (breaking change, which have impact to existing functionality)

**Versions**
* Microgateway: 2.0
* Helm Chart: 0.7.0

## Checklist:
- [x] The code has been reviewed (self-review, ...).
- [x] The corresponding documentation has been updated.

