### PR TITLE
Remove advanced dsl mode

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Install helm-docs
         run: .github/helm-docs-install.sh
         env:
-          HELM_DOCS_VERSION: "0.12.0"
+          HELM_DOCS_VERSION: "1.5.0"
       - name: Run helm-docs
         id: validatedocs
         run: .github/helm-docs-verify.sh

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 helm-docs:
 	@echo --- Generating Chart READMEs
-	@docker run --rm -v $$(pwd):/helm-docs -u $$(id -u) jnorwood/helm-docs:v0.13.0
+	@docker run --rm -v $$(pwd):/helm-docs -u $$(id -u) jnorwood/helm-docs:v1.5.0

--- a/charts/microgateway/README.md
+++ b/charts/microgateway/README.md
@@ -433,7 +433,7 @@ For a full list of available Microgateway configuration parameters refer to the 
 ### DSL Environment Variables
 Environment variables can be configured with the Helm chart and used within the [DSL Configuration](#dsl-configuration).
 This works for both simple and expert DSL configuration mode.
-The example below illustrates how to configure environment variables in combination with the [Simple DSL configuration](#simple-dsl-configuration).
+The example below illustrates how to configure environment variables in combination with the [Expert DSL configuration](#expert-dsl-configuration).
 
   env-variables.yaml
   ```

--- a/charts/microgateway/README.md.gotmpl
+++ b/charts/microgateway/README.md.gotmpl
@@ -331,7 +331,7 @@ For a full list of available Microgateway configuration parameters refer to the 
 ## Environment variables
 Environment variables can be configured with the Helm chart and used within the [DSL Configuration](#dsl-configuration).
 This works for both simple and expert DSL configuration mode.
-The example below illustrates how to configure environment variables in combination with the [Simple DSL configuration](#simple-dsl-configuration).
+The example below illustrates how to configure environment variables in combination with the [Expert DSL configuration](#expert-dsl-configuration).
 
   env-variables.yaml
   ```

--- a/charts/microgateway/README.md.gotmpl
+++ b/charts/microgateway/README.md.gotmpl
@@ -23,10 +23,9 @@ The current chart version is: {{ template "chart.version" . }}
 * [Dependencies](#dependencies)
   * [Redis](#redis)
   * [Echo-Server](#echo-server)
-* [DSL configuration](#dsl-configuration)
-  * [Simple DSL configuration](#simple-dsl-configuration)
-  * [Advanced DSL configuration](#advanced-dsl-configuration)
-  * [Expert DSL configuration](#expert-dsl-configuration)
+* [DSL Configuration](#dsl-configuration)
+  * [Simple DSL Configuration](#simple-dsl-configuration)
+  * [Expert DSL Configuration](#expert-dsl-configuration)
 * [Environment variables](#environment-variables)
 * [Extra Volumes](#extra-volumes)
 * [Probes](#probes)
@@ -218,12 +217,14 @@ Finally, apply the Helm chart configuration file with `-f` parameter.
 :information_source: **Possible settings**:<br>
 Please refer to the [Echo-Server Helm chart](https://ealenn.github.io/Echo-Server/pages/helm.html) to see all possible parameters of the Echo-Server Helm chart.
 
-## DSL configuration
-The Helm chart provides three different possibilities to configure the Microgateway.
-Depending on the environment and use case, one of the options might suit better and be easier to implement.
+## DSL Configuration
+The Helm chart provides two different configuration modes for the Microgateway.
+Depending on your environment and use case, one of these options may better suit your needs.
+* The **simple configuration mode** is designed to get you started quickly. It supports one virtual host and one Backend System. Some of the more advanced Microgateway functions are not supported.
+* The **expert configuration mode** supports multiple virtual hosts and backend systems, and all of the advanced Microgatway features.
 
-### Simple DSL configuration
-The simple DSL configuration mode is designed for a quick start with the microgateway. It does not support many of its advanced features.
+### Simple DSL Configuration
+The simple DSL configuration mode is designed for a quick start with the microgateway. It does not support some of its advanced features.
 The simple DSL configuration supports the following use case:
 | Virtual Host | Mapping | Backend Service |
 |--|--|--|
@@ -233,7 +234,8 @@ Restrictions of the Simple DSL configuration mode:
 * Only one Virtual Host is configured.
 * Only one Mapping is configured.
 * Only one backend service is configured.
-* Deny rules can only be configured on a global level, fine-grained control is not possible.
+* Deny rules can only be configured on a global level, for fine-grained control the expert DSL configuration mode is required.
+* Allow rules can not be configured.
 
 The example below shows how to adjust the default values that are preconfigured in the simple DSL configuration mode:
 
@@ -274,89 +276,11 @@ The example below shows how to adjust the default values that are preconfigured 
 * `config.global.*`
 * `config.generic.*`
 
-### Advanced DSL configuration
-In case that the [Simple DSL configuration](#simple-dsl-configuration) does not suite, the advanced configuration options might help. The following use cases might require this kind of configuration:
-
-**_Use Case 1)_**
-| Virtual Host | Mapping | Backend Service |
-|--|--|--|
-| VH1 (hostname: virtinc.com) | M1 (entry_path: /) | BE1 |
-| VH2 (hostname: example.com) | M2 (entry_path: /) | BE1 |
-
-**_Use Case 2)_**
-| Virtual Host | Mapping | Backend Service |
-|--|--|--|
-| VH1 (hostname: virtinc.com) | M1 (entry_path: /)<br>M2 (entry_path: /auth/) | BE1 |
-
-**_Use Case 3)_**
-| Virtual Host | Mapping | Backend Service |
-|--|--|--|
-| VH1 (hostname: virtinc.com) | M1 (entry_path: /) | BE1 |
-| VH2 (hostname: example.com) | M2 (entry_path: /) | BE2 |
-
-The use cases outlined above can also occur slightly differently. But all of them have in common that more than one Virtual Hosts, Mappings or Backend Services are used. Whenever this is the case, the [Advanced DSL configuration](#advanced-dsl-configuration) should be preferred over the [Simple DSL configuration](#simple-dsl-configuration).
-
-**Example:**
-
-  custom-values.yaml
-  ```
-  config:
-    global:
-      ip_header:
-        trusted_proxies:
-          - 10.0.0.0/28
-    advanced:
-      apps:
-        - virtual_host:
-            hostname: virtinc.com
-          mappings:
-            - name: webapp
-              entry_path: /
-              operational_mode: integration
-              session_handling: enforce_session
-              deny_rule_groups:
-                - level: standard
-                  exceptions:
-                    - parameter_name:
-                        pattern: ^content$
-                        ignore_case: true
-                      path:
-                        pattern: ^/mail/
-                      method:
-                        pattern: ^POST$
-              backend:
-                hosts:
-                  - protocol: https
-                    name: custom-backend-service
-                    port: 8443
-            - name: api
-              entry_path: /api/
-              session_handling: ignore_session
-              deny_rule_groups:
-                - level: strict
-              openapi:
-                spec_file: /config/virtinc_api_openapi.json
-              backend:
-                hosts:
-                  - protocol: https
-                    name: custom-backend-service
-                    port: 8443
-
-  redis:
-    enabled: true
-  ```
-
-**`config.*` Parameters which can be used**:
-* `config.advanced.apps` - **must** be used.
-* `config.global.*`
-* `config.generic.*`
-
 ### Expert DSL configuration
-In case that the [Advanced DSL configuration](#advanced-dsl-configuration) does not suite, the expert configuration options must be used. There are a few reasons listed below:
+The Expert DSL configuration mode offers more flexibility than the [Simple DSL configuration](#simple-dsl-configuration) mode.
+It is possible to use all Microgateway configuration options within the 'dsl' configuration parameter.
 
-* The Microgateway DSL configuration options are not available as Helm chart parameters (e.g. session.store_mode, ...)
-* The Microgateway DSL configuration file has already been used/tested thorougly. To reduce the risk of a broken or unsecure configuration, do not modify the pre-configured configuration file.
-
+For a full list of available Microgateway configuration parameters refer to the [Microgateway Documentation](https://docs.airlock.com/microgateway/{{ template "chart.appVersion" . }}/)
 
 **Example:**
 
@@ -406,7 +330,8 @@ In case that the [Advanced DSL configuration](#advanced-dsl-configuration) does 
 
 ## Environment variables
 Environment variables can be configured with the Helm chart and used within the [DSL Configuration](#dsl-configuration).
-This works for all three DSL of the above configuration setups (simple, advanced and expert). The example below illustrates how to configure environment variables in combination with the [Simple DSL configuration](#simple-dsl-configuration).
+This works for both simple and expert DSL configuration mode.
+The example below illustrates how to configure environment variables in combination with the [Simple DSL configuration](#simple-dsl-configuration).
 
   env-variables.yaml
   ```
@@ -422,11 +347,16 @@ This works for all three DSL of the above configuration setups (simple, advanced
   custom-values.yaml
   ```
   config:
-    simple:
-      mapping:
-        operational_mode: "@@ALG_CFG_OPERATIONAL_MODE@@"
-        deny_rules:
-          log_only: "@@ALG_CFG_LOG_ONLY@@"
+    expert:
+      dsl:
+        apps:
+          - virtual_host:
+              hostname: virtinc.com
+            mappings:
+              - name: webapp
+                operational_mode: "@@ALG_CFG_OPERATIONAL_MODE@@"
+                deny_rules:
+                  log_only: "@@ALG_CFG_LOG_ONLY@@"
   ```
 
 Finally, apply the Helm chart configuration file with `-f` parameter.
@@ -450,11 +380,14 @@ extraVolumeMounts:
     subPath: mapping.xml
 
 config:
-  advanced:
-    apps:
-      - mappings:
-        - name: virtinc
-          mapping_template_path: /config/template/mapping.xml
+  expert:
+    dsl:
+      apps:
+      - virtual_host:
+          hostname: virtinc.com
+        mappings:
+          - name: virtinc
+            mapping_template_path: /config/template/mapping.xml
 ```
 
 ## Probes

--- a/charts/microgateway/templates/configmap.yaml
+++ b/charts/microgateway/templates/configmap.yaml
@@ -9,7 +9,9 @@ metadata:
   labels:
     {{- include "microgateway.labels" . | nindent 4 }}
 data:
-{{- if not $config.expert.dsl }}
+{{- if $config.expert.dsl }}
+  config.yaml: |{{ toYaml $config.expert.dsl | nindent 4 }}
+{{- else }}
   config.yaml: |
     license_file: /secret/config/license
     session:
@@ -72,10 +74,6 @@ data:
       {{- end }}
     {{- end }}
   {{- end }}
-
-  {{- with $config.advanced.apps }}
-    apps: {{ toYaml . | nindent 4 }}
-  {{- else }}
     apps:
     - mappings:
       - entry_path: {{ $simple.mapping.entry_path }}
@@ -106,7 +104,4 @@ data:
           privatekey_file: /secret/tls/frontend-server.key
           ca_chain_file: /secret/tls/frontend-server-ca.crt
     {{- end }}
-  {{- end }}
-{{- else }}
-  config.yaml: |{{ toYaml $config.expert.dsl | nindent 4 }}
 {{- end }}

--- a/charts/microgateway/values.yaml
+++ b/charts/microgateway/values.yaml
@@ -46,9 +46,7 @@ config:
       # config.simple.backend.protocol -- Backend protocol
       protocol: http
 
-  # config.global -- Available for:<br>
-  # - [Simple DSL configuration](#simple-dsl-configuration)<br>
-  # - [Advanced DSL configuration](#advanced-dsl-configuration)
+  # config.global -- Available for [Simple DSL configuration](#simple-dsl-configuration)<br>
   # @default -- See `config.global.*`:
   global:
     expert_settings:
@@ -98,7 +96,6 @@ config:
 
   # config.generic -- Available for:<br>
   # - [Simple DSL configuration](#simple-dsl-configuration)<br>
-  # - [Advanced DSL configuration](#advanced-dsl-configuration)<br>
   # - [Expert DSL configuration](#expert-dsl-configuration)
   # @default -- See `config.generic.*`:
   generic:
@@ -129,10 +126,6 @@ config:
     # passphrase: `passphrase`
     # @default -- ""
     existingSecret:
-
-  # config.advanced.apps -- [Advanced DSL configuration](#advanced-dsl-configuration)
-  advanced:
-    apps: []
 
   # config.expert.dsl -- [Expert DSL configuration](#expert-dsl-configuration)
   expert:


### PR DESCRIPTION
# Pull Request Template

## Description

- Removes the advanced DSL configuration mode in the chart and in the documentation
- Adds more information on the purpose of simple and expert mode to the readme.
- Updates helm doc action to the latest version.

## Motivation
The advanced DSL mode does not offer much added value to the simple and expert mode and makes chart maintenance more complex.

## Type of change
Please delete options that are irrelevant.

- [x] Bug fix (breaking change, which have impact to existing functionality)
- [x] Documentation

**Versions**
* Microgateway: 2.0
* Helm Chart: 0.7.0


## Checklist:
- [x] The code has been reviewed (self-review, ...).
- [ ] The parts of the code which are hard to understand are commented.
- [x] The corresponding documentation has been updated.
- [ ] The changes do not cause warnings.
- [ ] The spelling has been checked.
