### PR TITLE
Ingress tls doku-fix

### DIFF
--- a/charts/microgateway/Chart.yaml
+++ b/charts/microgateway/Chart.yaml
@@ -14,5 +14,5 @@ maintainers:
   - email: support@airlock.com
     name: Airlock
 name: microgateway
-version: 0.6.3
+version: 0.6.4
 appVersion: "1.0"

--- a/charts/microgateway/README.md.gotmpl
+++ b/charts/microgateway/README.md.gotmpl
@@ -511,7 +511,8 @@ The Microgateway Helm chart itself does not install the nginx-ingress-controller
 #### Ingress terminating secure HTTPS
 The TLS certificate of the Ingress must be in a secret object which is referred to in the Ingress configuration.
 At the time of writing, Ingress supports only the default port 443 for HTTPS and directly assumes it is TLS.
-In case that multiple hosts are configured, TLS-SNI is used to distinguish what host the client requested.
+In case that multiple hosts are configured, TLS-SNI is used to distinguish what host the client requested.  
+For each configured `ingress.tls.host`, an `ingress.hosts` entry must also be created to ensure that the ingress rules are created correctly. 
 
   To receive HTTPS traffic from the outside of the Kubernetes cluster, use the following configuration:
   ```
@@ -526,6 +527,8 @@ In case that multiple hosts are configured, TLS-SNI is used to distinguish what 
       - secretName: virtinc-tls-secret
         hosts:
           - virtinc.com
+    hosts: 
+      - virtinc.com
   ```
 
 ### Openshift Route


### PR DESCRIPTION
## Description
When TLS is used for ingress, the TLS hosts are not specified in ingress.hosts. Then no rules for the ingress are created.
Therefore, the example for the configuration of Ingress with TLS in the documentation must be adapted. 


## To Reproduce
Use Helm chart 0.6.2
Configure the Ingress according to: https://github.com/ergon/airlock-helm-charts/tree/master/charts/microgateway#ingress-terminating-secure-https
The Ingress rule is configured with the default hosts from the values.yaml.

## Type of change
- [x] Documentation

**Versions**
* Microgateway: 1.0
* Helm Chart: 0.6.4

## Checklist:
- [x] The corresponding documentation has been updated.
