### PR TITLE
support routes without host name

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v1
       - name: Install helm-docs
         run: .github/helm-docs-install.sh
         env:
-          HELM_DOCS_VERSION: "0.12.0"
+          HELM_DOCS_VERSION: "1.5.0"
       - name: Run helm-docs
         id: validatedocs
         run: .github/helm-docs-verify.sh

--- a/charts/microgateway/Chart.yaml
+++ b/charts/microgateway/Chart.yaml
@@ -14,5 +14,5 @@ maintainers:
   - email: support@airlock.com
     name: Airlock
 name: microgateway
-version: 0.6.5
+version: 0.6.6
 appVersion: "1.0"

--- a/charts/microgateway/README.md
+++ b/charts/microgateway/README.md
@@ -43,6 +43,7 @@ The current chart version is: 0.6.6
       * [Route Edge configuration](#route-edge-configuration)
       * [Route Re-encrypt configuration](#route-re-encrypt-configuration)
       * [Route Passthrough configuration](#route-passthrough-configuration)
+    * [Automated Hostname Assignment](#automated-hostname-assignment)
 * [Security](#security)
   * [Store sensitive information in secrets](#store-sensitive-information-in-secrets)
     * [Secure handling of license and passphrase](#secure-handling-of-license-and-passphrase)
@@ -737,6 +738,18 @@ Therefore, no certificates need to be configured on the Route and termination ta
       termination: passthrough
       destinationCACertificate: ""
   ```
+
+#### Automated Hostname Assignment
+Openshift assigns an automatically generated hostname to a route if you do not provide one.
+You can achieve this by specifying an empty string as hostname.
+
+```
+route:
+  enabled: true
+  path: ""
+  hosts:
+    - ""
+```
 
 ## Security
 The following subchapters describes how to use and securely deploy the Microgateway.

--- a/charts/microgateway/README.md
+++ b/charts/microgateway/README.md
@@ -3,7 +3,6 @@
 The *Airlock Microgateway* is a component of the [Airlock Secure Access Hub](https://www.airlock.com/).
 It is the lightweight, container-based deployment form of the *Airlock Gateway*, a software appliance with reverse-proxy, Web Application Firewall (WAF) and API security functionality.
 
-
 The Airlock helm charts are used internally for testing the *Airlock Microgateway*. We make them available publicly under the [MIT license](https://github.com/ergon/airlock-helm-charts/blob/master/LICENSE).
 
 The current chart version is: 0.6.5
@@ -170,7 +169,7 @@ The following table lists configuration parameters of the Airlock Microgateway c
 | route | object | See `route.*`: | [Openshift Route](#openshift-route) |
 | route.annotations | object | `{}` | Annotations to set on the route. |
 | route.enabled | bool | `false` | Create a route object. |
-| route.hosts | list | `["virtinc.com"]` |  List of host names. <br> A route will be created for every host name listed. No route will be created if no hosts are specified. Use an empty string to generate a route without hostname. |
+| route.hosts | list | `["virtinc.com"]` | List of host names. <br> A route will be created for every host name listed. No route will be created if no hosts are specified. Use an empty string to generate a route without hostname. |
 | route.labels | object | `{}` | Additional labels add on the Microgateway route. |
 | route.path | string | `"/"` | Path for the route. |
 | route.targetPort | string | `"https"` | Target port of the service (`http`, `https` or `<number>`). |
@@ -455,7 +454,6 @@ In case that the [Advanced DSL configuration](#advanced-dsl-configuration) does 
 * The Microgateway DSL configuration options are not available as Helm chart parameters (e.g. session.store_mode, ...)
 * The Microgateway DSL configuration file has already been used/tested thorougly. To reduce the risk of a broken or unsecure configuration, do not modify the pre-configured configuration file.
 
-
 **Example:**
 
   custom-values.yaml
@@ -617,8 +615,8 @@ The Microgateway Helm chart itself does not install the nginx-ingress-controller
 #### Ingress terminating secure HTTPS
 The TLS certificate of the Ingress must be in a secret object which is referred to in the Ingress configuration.
 At the time of writing, Ingress supports only the default port 443 for HTTPS and directly assumes it is TLS.
-In case that multiple hosts are configured, TLS-SNI is used to distinguish what host the client requested.  
-For each configured `ingress.tls.host`, an `ingress.hosts` entry must also be created to ensure that the ingress rules are created correctly. 
+In case that multiple hosts are configured, TLS-SNI is used to distinguish what host the client requested. 
+For each configured `ingress.tls.host`, an `ingress.hosts` entry must also be created to ensure that the ingress rules are created correctly.
 
   To receive HTTPS traffic from the outside of the Kubernetes cluster, use the following configuration:
   ```
@@ -633,10 +631,9 @@ For each configured `ingress.tls.host`, an `ingress.hosts` entry must also be cr
       - secretName: virtinc-tls-secret
         hosts:
           - virtinc.com
-    hosts: 
+    hosts:
       - virtinc.com
   ```
-
 
 ### Openshift Route
 Since the Route controller is already available in an Openshift environment, nothing has to be installed additionally.
@@ -769,8 +766,8 @@ This is why it is better to create a secret containing license and passphrase us
 
 #### Credentials to pull image from Docker registry
 The Microgateway image is published in a private Docker registry to which only granted accounts have access.
-In order to download this image, the Helm chart needs the Docker credentials to authenticate against the Docker registry. 
-Either an already existing Docker secret is provided (`imagePullSecrets`) during the installation of the Microgateway, or a Kubernetes secret is created with the provided credentials (`imageCredentials`).    
+In order to download this image, the Helm chart needs the Docker credentials to authenticate against the Docker registry.
+Either an already existing Docker secret is provided (`imagePullSecrets`) during the installation of the Microgateway, or a Kubernetes secret is created with the provided credentials (`imageCredentials`).   
 
   The example below shows how to create a secret with the credentials to download the image from the Docker registry.
   ```
@@ -784,7 +781,7 @@ Either an already existing Docker secret is provided (`imagePullSecrets`) during
       - name: "docker-secret"
   ```
 
-  The following example shows how to configure the Helm chart so that a Kubernetes credential is created. 
+  The following example shows how to configure the Helm chart so that a Kubernetes credential is created.
 ```
 imageCredentials:
   enabled: true
@@ -807,7 +804,6 @@ Used for backend connection:
 * Certificate: `backend-client.crt`
 * Private key: `backend-client.key`
 * CA:          `backend-server-validation-ca.crt`
-
 
   The example below shows how to create a secret containing certificates for frontend and backend connections.
   ```

--- a/charts/microgateway/README.md
+++ b/charts/microgateway/README.md
@@ -170,7 +170,7 @@ The following table lists configuration parameters of the Airlock Microgateway c
 | route | object | See `route.*`: | [Openshift Route](#openshift-route) |
 | route.annotations | object | `{}` | Annotations to set on the route. |
 | route.enabled | bool | `false` | Create a route object. |
-| route.hosts | list | `["virtinc.com"]` |  List of host names. |
+| route.hosts | list | `["virtinc.com"]` |  List of host names. <br> A route will be created for every host name listed. No route will be created if no hosts are specified. Use an empty string to generate a route without hostname. |
 | route.labels | object | `{}` | Additional labels add on the Microgateway route. |
 | route.path | string | `"/"` | Path for the route. |
 | route.targetPort | string | `"https"` | Target port of the service (`http`, `https` or `<number>`). |

--- a/charts/microgateway/README.md
+++ b/charts/microgateway/README.md
@@ -5,7 +5,7 @@ It is the lightweight, container-based deployment form of the *Airlock Gateway*,
 
 The Airlock helm charts are used internally for testing the *Airlock Microgateway*. We make them available publicly under the [MIT license](https://github.com/ergon/airlock-helm-charts/blob/master/LICENSE).
 
-The current chart version is: 0.6.5
+The current chart version is: 0.6.6
 
 ## About Ergon
 *Airlock* is a registered trademark of [Ergon](https://www.ergon.ch). Ergon is a Swiss leader in leveraging digitalisation to create unique and effective client benefits, from conception to market, the result of which is the international distribution of globally revered products.

--- a/charts/microgateway/README.md.gotmpl
+++ b/charts/microgateway/README.md.gotmpl
@@ -42,6 +42,7 @@ The current chart version is: {{ template "chart.version" . }}
       * [Route Edge configuration](#route-edge-configuration)
       * [Route Re-encrypt configuration](#route-re-encrypt-configuration)
       * [Route Passthrough configuration](#route-passthrough-configuration)
+    * [Automated Hostname Assignment](#automated-hostname-assignment)
 * [Security](#security)
   * [Store sensitive information in secrets](#store-sensitive-information-in-secrets)
     * [Secure handling of license and passphrase](#secure-handling-of-license-and-passphrase)
@@ -633,7 +634,7 @@ Therefore, no certificates need to be configured on the Route and termination ta
       destinationCACertificate: ""
   ```
 
-#### Automated Assignment of Hostname
+#### Automated Hostname Assignment
 Openshift assigns an automatically generated hostname to a route if you do not provide one.
 You can achieve this by specifying an empty string as hostname.
 

--- a/charts/microgateway/README.md.gotmpl
+++ b/charts/microgateway/README.md.gotmpl
@@ -511,8 +511,8 @@ The Microgateway Helm chart itself does not install the nginx-ingress-controller
 #### Ingress terminating secure HTTPS
 The TLS certificate of the Ingress must be in a secret object which is referred to in the Ingress configuration.
 At the time of writing, Ingress supports only the default port 443 for HTTPS and directly assumes it is TLS.
-In case that multiple hosts are configured, TLS-SNI is used to distinguish what host the client requested.  
-For each configured `ingress.tls.host`, an `ingress.hosts` entry must also be created to ensure that the ingress rules are created correctly. 
+In case that multiple hosts are configured, TLS-SNI is used to distinguish what host the client requested.
+For each configured `ingress.tls.host`, an `ingress.hosts` entry must also be created to ensure that the ingress rules are created correctly.
 
   To receive HTTPS traffic from the outside of the Kubernetes cluster, use the following configuration:
   ```
@@ -527,7 +527,7 @@ For each configured `ingress.tls.host`, an `ingress.hosts` entry must also be cr
       - secretName: virtinc-tls-secret
         hosts:
           - virtinc.com
-    hosts: 
+    hosts:
       - virtinc.com
   ```
 
@@ -633,6 +633,18 @@ Therefore, no certificates need to be configured on the Route and termination ta
       destinationCACertificate: ""
   ```
 
+#### Automated Assignment of Hostname
+Openshift assigns an automatically generated hostname to a route if you do not provide one.
+You can achieve this by specifying an empty string as hostname.
+
+```
+route:
+  enabled: true
+  path: ""
+  hosts:
+    - ""
+```
+
 ## Security
 The following subchapters describes how to use and securely deploy the Microgateway.
 
@@ -663,8 +675,8 @@ This is why it is better to create a secret containing license and passphrase us
 
 #### Credentials to pull image from Docker registry
 The Microgateway image is published in a private Docker registry to which only granted accounts have access.
-In order to download this image, the Helm chart needs the Docker credentials to authenticate against the Docker registry. 
-Either an already existing Docker secret is provided (`imagePullSecrets`) during the installation of the Microgateway, or a Kubernetes secret is created with the provided credentials (`imageCredentials`).    
+In order to download this image, the Helm chart needs the Docker credentials to authenticate against the Docker registry.
+Either an already existing Docker secret is provided (`imagePullSecrets`) during the installation of the Microgateway, or a Kubernetes secret is created with the provided credentials (`imageCredentials`).
 
   The example below shows how to create a secret with the credentials to download the image from the Docker registry.
   ```
@@ -678,7 +690,7 @@ Either an already existing Docker secret is provided (`imagePullSecrets`) during
       - name: "docker-secret"
   ```
 
-  The following example shows how to configure the Helm chart so that a Kubernetes credential is created. 
+  The following example shows how to configure the Helm chart so that a Kubernetes credential is created.
 ```
 imageCredentials:
   enabled: true

--- a/charts/microgateway/templates/route.yaml
+++ b/charts/microgateway/templates/route.yaml
@@ -1,12 +1,12 @@
 {{- $route := .Values.route -}}
 {{- $fullName := include "microgateway.fullname" . -}}
 {{- if $route.enabled -}}
-{{- range $route.hosts }}
+{{- range $index, $host := $route.hosts }}
 ---
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-  name: {{ . | replace "." "-" | lower }}
+  name: {{ $fullName }}-{{ $index }}
   labels:
     {{- include "microgateway.labels" $ | nindent 4 }}
   {{- with $.Values.route.labels }}
@@ -17,7 +17,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
 {{- end }}
 spec:
-  host: {{ . }}
+  host: {{ $host }}
   path: {{ $route.path }}
   port:
     targetPort: {{ $route.targetPort }}

--- a/charts/microgateway/values.yaml
+++ b/charts/microgateway/values.yaml
@@ -227,7 +227,10 @@ route:
     # haproxy.router.openshift.io/balance: roundrobin
   # route.labels -- Additional labels add on the Microgateway route.
   labels: {}
-  # route.hosts --  List of host names.
+  # route.hosts --  List of host names. <br>
+  # A route will be created for every host name listed. No route will be created
+  # if no hosts are specified.
+  # Use an empty string to generate a route without hostname.
   hosts:
     - virtinc.com
   # route.path -- Path for the route.


### PR DESCRIPTION
- route name is derived from deployment name and route index and not from hostname
- enhanced documentation of hosts parameter in route

# Pull Request Template

## Description

Please include a summary of the change and which issues are fixed or what feature it provides.

- closes #52