### PR TITLE
fix expert DSL example

### DIFF
--- a/charts/microgateway/README.md
+++ b/charts/microgateway/README.md
@@ -422,11 +422,13 @@ For a full list of available Microgateway configuration parameters refer to the 
               hostname: virtinc.com
             mappings:
               - name: webapp
-                entry_path: /
+                entry_path:
+                  value: /
                 operational_mode: integration
                 session_handling: enforce_session
               - name: api
-                entry_path: /api/
+                entry_path:
+                  value: /api/
                 session_handling: ignore_session
                 openapi:
                   spec_file: /config/virtinc_api_openapi.json

--- a/charts/microgateway/README.md.gotmpl
+++ b/charts/microgateway/README.md.gotmpl
@@ -310,11 +310,13 @@ For a full list of available Microgateway configuration parameters refer to the 
               hostname: virtinc.com
             mappings:
               - name: webapp
-                entry_path: /
+                entry_path:
+                  value: /
                 operational_mode: integration
                 session_handling: enforce_session
               - name: api
-                entry_path: /api/
+                entry_path:
+                  value: /api/
                 session_handling: ignore_session
                 openapi:
                   spec_file: /config/virtinc_api_openapi.json


### PR DESCRIPTION
In the Expert DSL mode example in the readme, reflect the new syntax for mapping entry path.
