### PR TITLE
renamed config.generic Parameters to config.*

### DIFF
--- a/charts/microgateway/CHANGE-NOTES.md
+++ b/charts/microgateway/CHANGE-NOTES.md
@@ -9,7 +9,8 @@
 
 - Advanced and Simple DSL Configuration are not supported anymore. Configurations using Advanced or Simple DSL Mode will have to migrate to the standard Microgateway DSL configuration. Please refer to the [Microgateway Documentation](https://docs.airlock.com/microgateway/2.0) for further information.
 - DSL Configuration chart parameter 'config.expert.dsl' has been renamed to 'config.dsl'.
-- Helm Chart parameter 'config.generic.env' has been renamed to 'config.generic.configEnv'
+- Parameters 'config.generic.\*' have been renamed to 'config.\*'. Example: 'config.generic.passphrase' has been renamed to 'config.passphrase'.
+- Helm Chart parameter 'config.generic.env' has been renamed to 'config.configEnv'
 - The service name for the echo service has been changed from 'backend-service' to 'backend' to match the microgateway default value. The echo service name can be configured using 'echo-server.fullnameOverride'.
 
 #### Breaking Changes in the Microgateway DSL

--- a/charts/microgateway/README.md
+++ b/charts/microgateway/README.md
@@ -95,14 +95,13 @@ The following table lists configuration parameters of the Airlock Microgateway c
 |-----|------|---------|-------------|
 | affinity | string | `nil` | Assign custom [affinity rules](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) (multiline string). |
 | commonLabels | object | `{}` | Labels to add to all resources. |
+| config.configEnv | list | `[]` | [DSL Environment Variables](#dsl-environment-variables) |
 | config.dsl | object | `{}` | [DSL configuration](#dsl-configuration) |
-| config.generic | object | See `config.generic.*`: |  |
-| config.generic.configEnv | list | `[]` | [DSL Environment Variables](#dsl-environment-variables) |
-| config.generic.existingSecret | string | "" | Name of an existing secret containing:<br><br> license: `license`<br> passphrase: `passphrase` |
-| config.generic.license | string | "" | License (multiline string) |
-| config.generic.passphrase | string | - `passphrase`<br> If `passphrase` in `config.generic.existingSecret` <br><br> - `<generated passphrase>`<br> If no passphrase available. | Passphrase used for encryption. |
-| config.generic.runtimeEnv | list | `[]` | [Runtime Environment Variables](#runtime-environment-variables) |
-| config.generic.tlsSecretName | string | "" | Name of an existing secret containing:<br><br> _Virtual Host:_<br> Certificate: `frontend-server.crt`<br> Private key: `frontend-server.key`<br> CA: `frontend-server-ca.crt` <br> :exclamation: Update `route.tls.destinationCACertificate` accordingly.<br><br> _Backend:_<br> Certificate: `backend-client.crt`<br> Private key: `backend-client.key`<br> CA: `backend-server-validation-ca.crt` |
+| config.existingSecret | string | "" | Name of an existing secret containing:<br><br> license: `license`<br> passphrase: `passphrase` |
+| config.license | string | "" | License (multiline string) |
+| config.passphrase | string | - `passphrase`<br> If `passphrase` in `config.existingSecret` <br><br> - `<generated passphrase>`<br> If no passphrase available. | Passphrase used for encryption. |
+| config.runtimeEnv | list | `[]` | [Runtime Environment Variables](#runtime-environment-variables) |
+| config.tlsSecretName | string | "" | Name of an existing secret containing:<br><br> _Virtual Host:_<br> Certificate: `frontend-server.crt`<br> Private key: `frontend-server.key`<br> CA: `frontend-server-ca.crt` <br> :exclamation: Update `route.tls.destinationCACertificate` accordingly.<br><br> _Backend:_<br> Certificate: `backend-client.crt`<br> Private key: `backend-client.key`<br> CA: `backend-server-validation-ca.crt` |
 | echo-server | object | See `echo-server.*`: | Pre-configured [Echo-Server](#echo-server). |
 | echo-server.enabled | bool | `false` | Deploy pre-configured [Echo-Server](#echo-server). |
 | extraVolumeMounts | list | `[]` | Add additional volume mounts. |
@@ -186,13 +185,12 @@ This section describes how to configure a license for the Microgateway. By follo
 ```
 ---
 config:
-  generic:
-    license: |
-      -----BEGIN LICENSE-----
-      eJxFkEnTokgURf+LWzsCEBCpiFowKoMg8KUIZS8YUoZUEkgmqaj/XnYvqpbv
-      [...]
-      bHy/N5tf//76DY17EVk=
-      -----END LICENSE-----
+  license: |
+    -----BEGIN LICENSE-----
+    eJxFkEnTokgURf+LWzsCEBCpiFowKoMg8KUIZS8YUoZUEkgmqaj/XnYvqpbv
+    [...]
+    bHy/N5tf//76DY17EVk=
+    -----END LICENSE-----
 ```
 
 2. [Create the image pull secret](#credentials-to-pull-image-from-docker-registry) to pull the microgateway image.
@@ -217,8 +215,7 @@ The Airlock Microgateway Helm chart has many parameters and most of them are alr
   custom-values.yaml
   ```
   config:
-    generic:
-      existingSecret: "microgatewaysecrets"
+    existingSecret: "microgatewaysecrets"
     dsl:
       license_file: /secret/config/license
       session:
@@ -373,12 +370,11 @@ The example below illustrates how to configure environment variables in combinat
   env-variables.yaml
   ```
   config:
-    generic:
-      configEnv:
-        - name: OPERATIONAL_MODE
-          value: integration
-        - name: DR_LOG_ONLY
-          value: true
+    configEnv:
+      - name: OPERATIONAL_MODE
+        value: integration
+      - name: DR_LOG_ONLY
+        value: true
   ```
 
   custom-values.yaml
@@ -408,10 +404,9 @@ The following example shows how to set the timezone of the microgateway:
 env-variables.yaml
 ```
 config:
-  generic:
-    runtimeEnv:
-      - name: TZ
-        value: Europe/Zurich
+  runtimeEnv:
+    - name: TZ
+      value: Europe/Zurich
 ```
 
 ## Extra Volumes
@@ -642,8 +637,8 @@ The following subchapters describe which information should be protected and how
 
 #### Secure handling of license and passphrase
 It is possible to use the following parameters of this Helm chart to configure license and passphrase:
-* License: `config.generic.license`
-* Passphrase: `config.generic.passphrase`
+* License: `config.license`
+* Passphrase: `config.passphrase`
 
 The Helm chart itself creates a secret and configures the Microgateway to use it. While this is already secure, because it is stored as a secret, this information might end in a Git repo or somewhere else, where too many people have access to it.
 This is why it is better to create a secret containing license and passphrase using a different process.
@@ -657,8 +652,7 @@ This is why it is better to create a secret containing license and passphrase us
   custom-values.yaml
   ```
   config:
-    generic:
-      existingSecret: "microgateway-secrets"
+    existingSecret: "microgateway-secrets"
   ```
 
 #### Credentials to pull image from Docker registry
@@ -716,8 +710,7 @@ Used for backend connection:
   Afterwards use this secret in the Helm chart configuration file.
   ```
   config:
-    generic:
-      tlsSecretName: "microgateway-tls"
+    tlsSecretName: "microgateway-tls"
   ```
 ### Service Account
 The Microgateway runs under a dedicated service account created with the deployment by default.

--- a/charts/microgateway/README.md.gotmpl
+++ b/charts/microgateway/README.md.gotmpl
@@ -102,13 +102,12 @@ This section describes how to configure a license for the Microgateway. By follo
 ```
 ---
 config:
-  generic:
-    license: |
-      -----BEGIN LICENSE-----
-      eJxFkEnTokgURf+LWzsCEBCpiFowKoMg8KUIZS8YUoZUEkgmqaj/XnYvqpbv
-      [...]
-      bHy/N5tf//76DY17EVk=
-      -----END LICENSE-----
+  license: |
+    -----BEGIN LICENSE-----
+    eJxFkEnTokgURf+LWzsCEBCpiFowKoMg8KUIZS8YUoZUEkgmqaj/XnYvqpbv
+    [...]
+    bHy/N5tf//76DY17EVk=
+    -----END LICENSE-----
 ```
 
 2. [Create the image pull secret](#credentials-to-pull-image-from-docker-registry) to pull the microgateway image.
@@ -133,8 +132,7 @@ The Airlock Microgateway Helm chart has many parameters and most of them are alr
   custom-values.yaml
   ```
   config:
-    generic:
-      existingSecret: "microgatewaysecrets"
+    existingSecret: "microgatewaysecrets"
     dsl:
       license_file: /secret/config/license
       session:
@@ -286,12 +284,11 @@ The example below illustrates how to configure environment variables in combinat
   env-variables.yaml
   ```
   config:
-    generic:
-      configEnv:
-        - name: OPERATIONAL_MODE
-          value: integration
-        - name: DR_LOG_ONLY
-          value: true
+    configEnv:
+      - name: OPERATIONAL_MODE
+        value: integration
+      - name: DR_LOG_ONLY
+        value: true
   ```
 
   custom-values.yaml
@@ -321,10 +318,9 @@ The following example shows how to set the timezone of the microgateway:
 env-variables.yaml
 ```
 config:
-  generic:
-    runtimeEnv:
-      - name: TZ
-        value: Europe/Zurich
+  runtimeEnv:
+    - name: TZ
+      value: Europe/Zurich
 ```
 
 ## Extra Volumes
@@ -556,8 +552,8 @@ The following subchapters describe which information should be protected and how
 
 #### Secure handling of license and passphrase
 It is possible to use the following parameters of this Helm chart to configure license and passphrase:
-* License: `config.generic.license`
-* Passphrase: `config.generic.passphrase`
+* License: `config.license`
+* Passphrase: `config.passphrase`
 
 The Helm chart itself creates a secret and configures the Microgateway to use it. While this is already secure, because it is stored as a secret, this information might end in a Git repo or somewhere else, where too many people have access to it.
 This is why it is better to create a secret containing license and passphrase using a different process.
@@ -571,8 +567,7 @@ This is why it is better to create a secret containing license and passphrase us
   custom-values.yaml
   ```
   config:
-    generic:
-      existingSecret: "microgateway-secrets"
+    existingSecret: "microgateway-secrets"
   ```
 
 #### Credentials to pull image from Docker registry
@@ -631,8 +626,7 @@ Used for backend connection:
   Afterwards use this secret in the Helm chart configuration file.
   ```
   config:
-    generic:
-      tlsSecretName: "microgateway-tls"
+    tlsSecretName: "microgateway-tls"
   ```
 ### Service Account
 The Microgateway runs under a dedicated service account created with the deployment by default.

--- a/charts/microgateway/ci/dsl-values.yaml
+++ b/charts/microgateway/ci/dsl-values.yaml
@@ -1,6 +1,5 @@
 config:
-  generic:
-    existingSecret: "microgatewaysecrets"
+  existingSecret: "microgatewaysecrets"
   dsl:
     license_file: /secret/config/license
     session:

--- a/charts/microgateway/templates/_helpers.tpl
+++ b/charts/microgateway/templates/_helpers.tpl
@@ -58,7 +58,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Return true if a secret object should be created
 */}}
 {{- define "microgateway.createSecret" -}}
-{{- if not .Values.config.generic.existingSecret -}}
+{{- if not .Values.config.existingSecret -}}
   {{- true -}}
 {{- end -}}
 {{- end -}}
@@ -67,14 +67,14 @@ Return true if a secret object should be created
 Get the secret name
 */}}
 {{- define "microgateway.secretName" -}}
-{{- if and .Values.config.generic.passphrase .Values.config.generic.existingSecret }}
+{{- if and .Values.config.passphrase .Values.config.existingSecret }}
   {{- fail "Please either specify an existing secret or the passphrase itself" }}
 {{- end }}
-{{- if and .Values.config.generic.license .Values.config.generic.existingSecret }}
+{{- if and .Values.config.license .Values.config.existingSecret }}
   {{- fail "Please either specify an existing secret or the license itself" }}
 {{- end }}
-{{- if .Values.config.generic.existingSecret }}
-  {{- printf "%s" .Values.config.generic.existingSecret -}}
+{{- if .Values.config.existingSecret }}
+  {{- printf "%s" .Values.config.existingSecret -}}
 {{- else -}}
   {{- printf "%s" (include "microgateway.fullname" .) -}}
 {{- end -}}

--- a/charts/microgateway/templates/deployment.yaml
+++ b/charts/microgateway/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
       - name: configbuilder
         image: "{{ .Values.image.repository_configbuilder }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        {{- with .Values.config.generic.configEnv }}
+        {{- with .Values.config.configEnv }}
         env: {{ toYaml . | nindent 10 }}
         {{- end }}
         volumeMounts:
@@ -45,7 +45,7 @@ spec:
         - name: secret
           mountPath: /secret/config/
           readOnly: true
-        {{- with .Values.config.generic.tlsSecretName }}
+        {{- with .Values.config.tlsSecretName }}
         - name: tls
           mountPath: /secret/tls/
           readOnly: true
@@ -68,7 +68,7 @@ spec:
           containerPort: 8443
         - name: probes
           containerPort: 9090
-        {{- with .Values.config.generic.runtimeEnv }}
+        {{- with .Values.config.runtimeEnv }}
         env: {{ toYaml . | nindent 10 }}
         {{- end }}
         volumeMounts:
@@ -108,7 +108,7 @@ spec:
       - name: secret
         secret:
           secretName: {{ template "microgateway.secretName" . }}
-      {{- with .Values.config.generic.tlsSecretName }}
+      {{- with .Values.config.tlsSecretName }}
       - name: tls
         secret:
           secretName: {{ . }}

--- a/charts/microgateway/templates/secret.yaml
+++ b/charts/microgateway/templates/secret.yaml
@@ -7,12 +7,12 @@ metadata:
     {{- include "microgateway.labels" . | nindent 4 }}
 type: Opaque
 data:
-{{- if .Values.config.generic.passphrase }}
-  passphrase: {{ .Values.config.generic.passphrase | b64enc | quote }}
+{{- if .Values.config.passphrase }}
+  passphrase: {{ .Values.config.passphrase | b64enc | quote }}
 {{- else }}
   passphrase: {{ randAlphaNum 128 | b64enc | quote }}
 {{- end }}
-{{- with .Values.config.generic.license }}
+{{- with .Values.config.license }}
   license: {{ . | b64enc | quote }}
 {{- end }}
 {{- end }}

--- a/charts/microgateway/tests/secret_test.yaml
+++ b/charts/microgateway/tests/secret_test.yaml
@@ -6,7 +6,7 @@ chart:
 tests:
   - it: create secret with given passphrase
     set:
-      config.generic.passphrase: "passphrase"
+      config.passphrase: "passphrase"
     asserts:
       - hasDocuments:
           count: 1
@@ -22,7 +22,7 @@ tests:
 
   - it: do not create passphrase secret if an existing secret is to be used
     set:
-      config.generic.existingSecret: existingSecret
+      config.existingSecret: existingSecret
     assert:
       - hasDocuments:
           count: 0
@@ -32,7 +32,7 @@ tests:
 
   - it: fail if existing passphrase and a passphrase to create are provided
     set:
-      config.generic.passphrase: "passphrase"
+      config.passphrase: "passphrase"
     assert:
       - hasDocuments:
           count: 0
@@ -42,7 +42,7 @@ tests:
 
   - it: create random secret if none is provided
     set:
-      config.generic.existingSecret: null
+      config.existingSecret: null
     asserts:
       - hasDocuments:
           count: 1
@@ -54,7 +54,7 @@ tests:
 
   - it: create license secret
     set:
-      config.generic.license: my_license
+      config.license: my_license
     asserts:
       - hasDocuments:
           count: 1
@@ -67,7 +67,7 @@ tests:
 
   - it: use existing secret in Deployment
     set:
-      config.generic.existingSecret: existingSecret
+      config.existingSecret: existingSecret
     asserts:
       - equal:
           path: spec.template.spec.volumes[1].secret.secretName
@@ -76,7 +76,7 @@ tests:
 
   - it: use created secret in Deployment
     set:
-      config.generic.passphrase: "passphrase"
+      config.passphrase: "passphrase"
     asserts:
       - equal:
           path: spec.template.spec.volumes[1].secret.secretName

--- a/charts/microgateway/values.yaml
+++ b/charts/microgateway/values.yaml
@@ -14,36 +14,33 @@ image:
 ## Microgateway Config
 ##
 config:
-  # config.generic --
-  # @default -- See `config.generic.*`:
-  generic:
-    # config.generic.configEnv -- [DSL Environment Variables](#dsl-environment-variables)
-    configEnv: []
-    # config.generic.runtimeEnv -- [Runtime Environment Variables](#runtime-environment-variables)
-    runtimeEnv: []
-    # config.generic.tlsSecretName -- (string) Name of an existing secret containing:<br><br>
-    # _Virtual Host:_<br>
-    # Certificate: `frontend-server.crt`<br>
-    # Private key: `frontend-server.key`<br>
-    # CA: `frontend-server-ca.crt` <br>
-    # :exclamation: Update `route.tls.destinationCACertificate` accordingly.<br><br>
-    # _Backend:_<br>
-    # Certificate: `backend-client.crt`<br>
-    # Private key: `backend-client.key`<br>
-    # CA: `backend-server-validation-ca.crt`
-    # @default -- ""
-    tlsSecretName:
-    # config.generic.passphrase -- Passphrase used for encryption.
-    # @default -- - `passphrase`<br> If `passphrase` in `config.generic.existingSecret` <br><br> - `<generated passphrase>`<br> If no passphrase available.
-    passphrase:
-    # config.generic.license -- (string) License (multiline string)
-    # @default -- ""
-    license:
-    # config.generic.existingSecret -- (string) Name of an existing secret containing:<br><br>
-    # license: `license`<br>
-    # passphrase: `passphrase`
-    # @default -- ""
-    existingSecret:
+  # config.configEnv -- [DSL Environment Variables](#dsl-environment-variables)
+  configEnv: []
+  # config.runtimeEnv -- [Runtime Environment Variables](#runtime-environment-variables)
+  runtimeEnv: []
+  # config.tlsSecretName -- (string) Name of an existing secret containing:<br><br>
+  # _Virtual Host:_<br>
+  # Certificate: `frontend-server.crt`<br>
+  # Private key: `frontend-server.key`<br>
+  # CA: `frontend-server-ca.crt` <br>
+  # :exclamation: Update `route.tls.destinationCACertificate` accordingly.<br><br>
+  # _Backend:_<br>
+  # Certificate: `backend-client.crt`<br>
+  # Private key: `backend-client.key`<br>
+  # CA: `backend-server-validation-ca.crt`
+  # @default -- ""
+  tlsSecretName:
+  # config.passphrase -- Passphrase used for encryption.
+  # @default -- - `passphrase`<br> If `passphrase` in `config.existingSecret` <br><br> - `<generated passphrase>`<br> If no passphrase available.
+  passphrase:
+  # config.license -- (string) License (multiline string)
+  # @default -- ""
+  license:
+  # config.existingSecret -- (string) Name of an existing secret containing:<br><br>
+  # license: `license`<br>
+  # passphrase: `passphrase`
+  # @default -- ""
+  existingSecret:
 
   # config.dsl -- [DSL configuration](#dsl-configuration)
   dsl: {}


### PR DESCRIPTION
# Pull Request Template
Rename config.generic.* parameters to config.*.

The support for multiple configuration modes has been removed, and generic parameters shared between these do no longer exist.
