### PR TITLE
Mount secrets to default location

### DIFF
--- a/charts/microgateway/CHANGE-NOTES.md
+++ b/charts/microgateway/CHANGE-NOTES.md
@@ -12,6 +12,7 @@
 - Parameters 'config.generic.\*' have been renamed to 'config.\*'. Example: 'config.generic.passphrase' has been renamed to 'config.passphrase'.
 - Helm Chart parameter 'config.generic.env' has been renamed to 'config.configEnv'
 - The service name for the echo service has been changed from 'backend-service' to 'backend' to match the microgateway default value. The echo service name can be configured using 'echo-server.fullnameOverride'.
+- Secrets for the license and the passphrase are now mounted to the default locations '/secret/license' and '/secret/passphrase' instead of '/secret/config/\*'. Explicit references to the former location of these secrets have to be removed from the DSL.
 
 #### Breaking Changes in the Microgateway DSL
 

--- a/charts/microgateway/README.md
+++ b/charts/microgateway/README.md
@@ -228,9 +228,7 @@ The Airlock Microgateway Helm chart has many parameters and most of them are alr
   config:
     existingSecret: "microgatewaysecrets"
     dsl:
-      license_file: /secret/config/license
       session:
-        encryption_passphrase_file: /secret/config/passphrase
         redis_hosts: [redis-master]
       expert_settings:
         apache: |
@@ -336,9 +334,7 @@ For a full list of available Microgateway configuration parameters refer to the 
   ```
   config:
     dsl:
-      license_file: /secret/config/license
       session:
-        encryption_passphrase_file: /secret/config/passphrase
         redis_hosts: [ redis-master ]
       log:
         level: info

--- a/charts/microgateway/README.md.gotmpl
+++ b/charts/microgateway/README.md.gotmpl
@@ -136,9 +136,7 @@ The Airlock Microgateway Helm chart has many parameters and most of them are alr
     generic:
       existingSecret: "microgatewaysecrets"
     dsl:
-      license_file: /secret/config/license
       session:
-        encryption_passphrase_file: /secret/config/passphrase
         redis_hosts: [redis-master]
       expert_settings:
         apache: |
@@ -241,9 +239,7 @@ For a full list of available Microgateway configuration parameters refer to the 
   ```
   config:
     dsl:
-      license_file: /secret/config/license
       session:
-        encryption_passphrase_file: /secret/config/passphrase
         redis_hosts: [ redis-master ]
       log:
         level: info

--- a/charts/microgateway/ci/dsl-values.yaml
+++ b/charts/microgateway/ci/dsl-values.yaml
@@ -2,9 +2,7 @@ config:
   generic:
     existingSecret: "microgatewaysecrets"
   dsl:
-    license_file: /secret/config/license
     session:
-      encryption_passphrase_file: /secret/config/passphrase
       redis_hosts: [redis-master]
     apps:
       - mappings:

--- a/charts/microgateway/templates/deployment.yaml
+++ b/charts/microgateway/templates/deployment.yaml
@@ -43,7 +43,12 @@ spec:
           subPath: config.yaml
           readOnly: true
         - name: secret
-          mountPath: /secret/config/
+          mountPath: /secret/passphrase
+          subPath: passphrase
+          readOnly: true
+        - name: secret
+          mountPath: /secret/license
+          subPath: license
           readOnly: true
         {{- with .Values.config.generic.tlsSecretName }}
         - name: tls


### PR DESCRIPTION
# Mount secrets to default location

## Description
The license and passphrase secrets are mounted to the default location. 

## Motivation
No explicit configuration of the secret files is required anymore.

## Type of change

- [x] Feature (breaking change, which have impact to existing functionality)
- [x] Documentation

