### PR TITLE
exclude test and development resources from package

### DIFF
--- a/charts/microgateway/.helmignore
+++ b/charts/microgateway/.helmignore
@@ -22,8 +22,8 @@
 *.tmproj
 .vscode/
 
-# CI
-ci
-
-# Unit Tests
-tests
+# helm chart folders and files
+ci/
+tests/
+README.md.gotmpl
+.helmignore


### PR DESCRIPTION
tests and ci folder as well as the .helmignore and the readme template are not included in the released packages.
