### PR TITLE
add option to mount DSL file from an existing ConfigMap

### DIFF
--- a/charts/microgateway/CHANGE-NOTES.md
+++ b/charts/microgateway/CHANGE-NOTES.md
@@ -1,4 +1,15 @@
 # Change Log
+## 2.2.0
+
+### Enhancements
+- An existing ConfigMap containing the DSL file can be mounted into the Microgateway pod using the parameter `config.dslConfigMap`. 
+
+## 2.1.0
+
+### Enhancements
+- Expose metrics port in the Microgateway Pod
+- Parameters for configuration of Deployment and Pod annotations
+
 ## 2.0.0
 
 ### Enhancements

--- a/charts/microgateway/Chart.yaml
+++ b/charts/microgateway/Chart.yaml
@@ -14,5 +14,5 @@ maintainers:
   - email: support@airlock.com
     name: Airlock
 name: microgateway
-version: 2.1.0
+version: 2.2.0
 appVersion: "2.1.0"

--- a/charts/microgateway/README.md
+++ b/charts/microgateway/README.md
@@ -5,7 +5,7 @@ It is the lightweight, container-based deployment form of the *Airlock Gateway*,
 
 The Airlock helm charts are used internally for testing the *Airlock Microgateway*. We make them available publicly under the [MIT license](https://github.com/ergon/airlock-helm-charts/blob/master/LICENSE).
 
-The current chart version is: 2.1.0
+The current chart version is: 2.2.0
 
 ## Change Notes
 [CHANGE-NOTES](CHANGE-NOTES.md) contains a list of noteworthy changes in the Microgateway Helm Chart.
@@ -98,7 +98,8 @@ The following table lists configuration parameters of the Airlock Microgateway c
 | affinity | string | `nil` | Assign custom [affinity rules](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) (multiline string). |
 | annotations | object | `{}` | Additional annotations for the Microgateway Deployment |
 | commonLabels | object | `{}` | Labels to add to all resources. |
-| config.dsl | object | `{}` | [DSL configuration](#dsl-configuration) |
+| config.dsl | object | `{}` | [DSL configuration](#dsl-configuration) Template rendering fails if both `config.dslConfigMap`and `config.dsl` are specified.  |
+| config.dslConfigMap | string | "" | Name of a config map containing the Microgateway DSL configuration file. <br> The DSL is expected in a data entry called `config.yaml`. <br> <br> Template rendering fails if both `config.dslConfigMap`and `config.dsl` are specified.  |
 | config.env | object | `{"configbuilder":[],"runtime":[]}` | [DSL Environment Variables](#dsl-environment-variables) |
 | config.env.configbuilder | list | `[]` | [DSL Environment Variables](#dsl-environment-variables) |
 | config.env.runtime | list | `[]` | [Runtime Environment Variables](#runtime-environment-variables) |
@@ -339,11 +340,13 @@ Finally, apply the Helm chart configuration file with `-f` parameter.
 Please refer to the [Echo-Server Helm chart](https://artifacthub.io/packages/helm/ealenn/echo-server) to see all possible parameters of the Echo-Server Helm chart.
 
 ## DSL Configuration
-It is possible to use all Microgateway DSL configuration options within the 'dsl' configuration parameter.
+The Microgateway DSL configuration can be provided in 2 different ways:
+- within the Helm Chart 'dsl' configuration parameter
+- in an existing ConfigMap mounted into the Microgatway pod
 
 For a full list of available Microgateway configuration parameters refer to the [Microgateway Documentation](https://docs.airlock.com/microgateway/latest/)
 
-**Example:**
+**Example DSL Parameter:**
 
   custom-values.yaml
   ```
@@ -378,6 +381,18 @@ For a full list of available Microgateway configuration parameters refer to the 
                   - protocol: https
                     name: custom-backend-service
                     port: 8443
+
+  redis:
+    enabled: true
+
+  ```
+
+**Example existing ConfigMap:**
+
+  custom-values.yaml
+  ```
+  config:
+    dslConfigMap: custom-map
 
   redis:
     enabled: true

--- a/charts/microgateway/README.md
+++ b/charts/microgateway/README.md
@@ -98,8 +98,8 @@ The following table lists configuration parameters of the Airlock Microgateway c
 | affinity | string | `nil` | Assign custom [affinity rules](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) (multiline string). |
 | annotations | object | `{}` | Additional annotations for the Microgateway Deployment |
 | commonLabels | object | `{}` | Labels to add to all resources. |
-| config.dsl | object | `{}` | [DSL configuration](#dsl-configuration) Template rendering fails if both `config.dslConfigMap`and `config.dsl` are specified.  |
-| config.dslConfigMap | string | "" | Name of a config map containing the Microgateway DSL configuration file. <br> The DSL is expected in a data entry called `config.yaml`. <br> <br> Template rendering fails if both `config.dslConfigMap`and `config.dsl` are specified.  |
+| config.dsl | object | `{}` | [DSL configuration](#dsl-configuration) Template rendering fails if both `config.dslConfigMap`and `config.dsl` are specified. |
+| config.dslConfigMap | string | "" | Name of a config map containing the Microgateway DSL configuration file. <br> The DSL is expected in a data entry called `config.yaml`. <br> <br> Template rendering fails if both `config.dslConfigMap`and `config.dsl` are specified. |
 | config.env | object | `{"configbuilder":[],"runtime":[]}` | [DSL Environment Variables](#dsl-environment-variables) |
 | config.env.configbuilder | list | `[]` | [DSL Environment Variables](#dsl-environment-variables) |
 | config.env.runtime | list | `[]` | [Runtime Environment Variables](#runtime-environment-variables) |

--- a/charts/microgateway/README.md
+++ b/charts/microgateway/README.md
@@ -98,8 +98,8 @@ The following table lists configuration parameters of the Airlock Microgateway c
 | affinity | string | `nil` | Assign custom [affinity rules](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) (multiline string). |
 | annotations | object | `{}` | Additional annotations for the Microgateway Deployment |
 | commonLabels | object | `{}` | Labels to add to all resources. |
-| config.dsl | object | `{}` | [DSL configuration](#dsl-configuration) Template rendering fails if both `config.dslConfigMap`and `config.dsl` are specified. |
-| config.dslConfigMap | string | "" | Name of a config map containing the Microgateway DSL configuration file. <br> The DSL is expected in a data entry called `config.yaml`. <br> <br> Template rendering fails if both `config.dslConfigMap`and `config.dsl` are specified. |
+| config.dsl | object | `{}` | [DSL configuration](#dsl-configuration) Template rendering fails if `config.dslConfigMap` and `config.dsl` are specified. |
+| config.dslConfigMap | string | "" | Name of the ConfigMap containing the Microgateway DSL configuration file. <br> The DSL is expected in a data entry called `config.yaml`. <br> <br> Template rendering fails if `config.dslConfigMap` and `config.dsl` are specified. |
 | config.env | object | `{"configbuilder":[],"runtime":[]}` | [DSL Environment Variables](#dsl-environment-variables) |
 | config.env.configbuilder | list | `[]` | [DSL Environment Variables](#dsl-environment-variables) |
 | config.env.runtime | list | `[]` | [Runtime Environment Variables](#runtime-environment-variables) |
@@ -392,11 +392,28 @@ For a full list of available Microgateway configuration parameters refer to the 
   custom-values.yaml
   ```
   config:
-    dslConfigMap: custom-map
+    dslConfigMap: microgateway-config
 
   redis:
     enabled: true
 
+  ```
+
+  microgateway-config.yaml
+  ```
+  apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: microgateway-config
+  data:
+    config.yaml: |
+      session:
+        redis_hosts: [redis-master]
+      log:
+        level: info
+
+      ...
+      ...
   ```
 
 ## Environment Variables

--- a/charts/microgateway/README.md
+++ b/charts/microgateway/README.md
@@ -344,6 +344,10 @@ The Microgateway DSL configuration can be provided in 2 different ways:
 - within the Helm Chart 'dsl' configuration parameter
 - in an existing ConfigMap mounted into the Microgatway pod
 
+:warning: **Changing the DSL configuration in a running system**:<br>
+The microgateway does not detect DSL changes at runtime. If the DSL configuration is managed by the Helm Chart, the Microgateway pod is restarted automatically after a DSL change.
+If the DSL is mounted from a volume not managed by the Helm Chart, a manual restart is required.
+
 For a full list of available Microgateway configuration parameters refer to the [Microgateway Documentation](https://docs.airlock.com/microgateway/latest/)
 
 **Example DSL Parameter:**

--- a/charts/microgateway/README.md.gotmpl
+++ b/charts/microgateway/README.md.gotmpl
@@ -234,6 +234,10 @@ The Microgateway DSL configuration can be provided in 2 different ways:
 - within the Helm Chart 'dsl' configuration parameter
 - in an existing ConfigMap mounted into the Microgatway pod
 
+:warning: **Changing the DSL configuration in a running system**:<br>
+The microgateway does not detect DSL changes at runtime. If the DSL configuration is managed by the Helm Chart, the Microgateway pod is restarted automatically after a DSL change. 
+If the DSL is mounted from a volume not managed by the Helm Chart, a manual restart is required.
+
 For a full list of available Microgateway configuration parameters refer to the [Microgateway Documentation](https://docs.airlock.com/microgateway/latest/)
 
 **Example DSL Parameter:**

--- a/charts/microgateway/README.md.gotmpl
+++ b/charts/microgateway/README.md.gotmpl
@@ -230,11 +230,13 @@ Finally, apply the Helm chart configuration file with `-f` parameter.
 Please refer to the [Echo-Server Helm chart](https://artifacthub.io/packages/helm/ealenn/echo-server) to see all possible parameters of the Echo-Server Helm chart.
 
 ## DSL Configuration
-It is possible to use all Microgateway DSL configuration options within the 'dsl' configuration parameter.
+The Microgateway DSL configuration can be provided in 2 different ways: 
+- within the Helm Chart 'dsl' configuration parameter
+- in an existing ConfigMap mounted into the Microgatway pod
 
 For a full list of available Microgateway configuration parameters refer to the [Microgateway Documentation](https://docs.airlock.com/microgateway/latest/)
 
-**Example:**
+**Example DSL Parameter:**
 
   custom-values.yaml
   ```
@@ -270,6 +272,18 @@ For a full list of available Microgateway configuration parameters refer to the 
                     name: custom-backend-service
                     port: 8443
 
+  redis:
+    enabled: true
+
+  ```
+
+**Example existing ConfigMap:**
+
+  custom-values.yaml
+  ```
+  config:
+    dslConfigMap: custom-map
+ 
   redis:
     enabled: true
 

--- a/charts/microgateway/README.md.gotmpl
+++ b/charts/microgateway/README.md.gotmpl
@@ -282,11 +282,28 @@ For a full list of available Microgateway configuration parameters refer to the 
   custom-values.yaml
   ```
   config:
-    dslConfigMap: custom-map
- 
+    dslConfigMap: microgateway-config
+
   redis:
     enabled: true
 
+  ```
+
+  microgateway-config.yaml
+  ```
+  apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: microgateway-config
+  data:
+    config.yaml: |
+      session:
+        redis_hosts: [redis-master]
+      log:
+        level: info
+
+      ...
+      ...
   ```
 
 ## Environment Variables

--- a/charts/microgateway/developer_notes.md
+++ b/charts/microgateway/developer_notes.md
@@ -14,7 +14,7 @@ Invoke from toplevel directory of this repository:
 $ helm unittest charts/microgateway
 ```
 ### Working with snapshots
-The configmap tests use snapshots to verify correct rendering of the configmap. These snapshots are checked into the repository as reference.
+The ConfigMap tests use snapshots to verify correct rendering of the ConfigMap. These snapshots are checked into the repository as reference.
 
 The snapshots are found in: 'charts/microgateway/tests/\__snapshot\__/'.
 

--- a/charts/microgateway/templates/_helpers.tpl
+++ b/charts/microgateway/templates/_helpers.tpl
@@ -108,13 +108,13 @@ return true if license secret should be mounted
 {{- end -}}
 
 {{/*
-return true if DSL Config Map should be created. Fails if both config.dsl and config.dslConfigMap are given.
+return true if DSL ConfigMap should be created. Fails if both config.dsl and config.dslConfigMap are given.
 */}}
 {{- define "microgateway.createConfigMap" -}}
 
 {{- if .Values.config.dslConfigMap }}
   {{- if .Values.config.dsl }}
-    {{- fail "Both 'config.dslConfigMap' and 'config.dsl' are specified." }}
+    {{- fail "'config.dslConfigMap' and 'config.dsl' are specified." }}
   {{- end -}}
   {{- false -}}
 {{- else -}}  

--- a/charts/microgateway/templates/_helpers.tpl
+++ b/charts/microgateway/templates/_helpers.tpl
@@ -108,6 +108,21 @@ return true if license secret should be mounted
 {{- end -}}
 
 {{/*
+return true if DSL Config Map should be created. Fails if both config.dsl and config.dslConfigMap are given.
+*/}}
+{{- define "microgateway.createConfigMap" -}}
+
+{{- if .Values.config.dslConfigMap }}
+  {{- if .Values.config.dsl }}
+    {{- fail "Both 'config.dslConfigMap' and 'config.dsl' are specified." }}
+  {{- end -}}
+  {{- false -}}
+{{- else -}}  
+  {{- true -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create imagePullSecret
 */}}
 {{- define "imagePullSecret" }}

--- a/charts/microgateway/templates/configmap.yaml
+++ b/charts/microgateway/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "microgateway.createConfigMap" .) "true" }}   
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,3 +7,4 @@ metadata:
     {{- include "microgateway.labels" . | nindent 4 }}
 data:
   config.yaml: |{{ toYaml .Values.config.dsl | nindent 4 }}
+{{- end }}

--- a/charts/microgateway/templates/deployment.yaml
+++ b/charts/microgateway/templates/deployment.yaml
@@ -18,7 +18,9 @@ spec:
       labels:
         {{- include "microgateway.selectorLabels" . | nindent 8 }}
       annotations:
+        {{- if eq (include "microgateway.createConfigMap" .) "true" }} 
         checksum/config: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- end }}
         {{- if not .Values.config.passphrase.useExistingSecret }}
         checksum/passphraseSecret: {{ include (print .Template.BasePath "/passphrasesecret.yaml") . | sha256sum }}
         {{- end }}

--- a/charts/microgateway/templates/deployment.yaml
+++ b/charts/microgateway/templates/deployment.yaml
@@ -123,7 +123,11 @@ spec:
       volumes:
       - name: config
         configMap:
-          name: {{ template "microgateway.fullname" . }}
+      {{- if eq (include "microgateway.createConfigMap" .) "true" }} 
+          name: {{ template "microgateway.fullname" . }}  
+      {{- else }}    
+          name: {{ .Values.config.dslConfigMap }}
+      {{- end }}        
       - name: passphrase-secret
         secret:
           secretName: {{ template "microgateway.passphraseSecretName" . }}

--- a/charts/microgateway/tests/configmap_test.yaml
+++ b/charts/microgateway/tests/configmap_test.yaml
@@ -1,18 +1,29 @@
 suite: test configmap
-templates:
-  - configmap.yaml
 release:
   name: my-microgateway
 chart:
   version: 1.0.1
+
 tests:
   - it: should be ConfigMap
     asserts:
       - isKind:
           of: ConfigMap
+    template: configmap.yaml
+
   - it: dsl example
     values:
       - ./values/dsl.yaml
     asserts:
       - matchSnapshot:
           path: data.[config.yaml]
+    template: configmap.yaml
+
+  - it: should be no configmap if one is provided
+    set:
+      config:
+        dslConfigMap: testmap
+    asserts:
+      - hasDocuments:
+          count: 0  
+    template: configmap.yaml

--- a/charts/microgateway/tests/deployment_test.yaml
+++ b/charts/microgateway/tests/deployment_test.yaml
@@ -75,6 +75,16 @@ tests:
         not: true
     templates:
       - deployment.yaml
+
+  - it: does not create config checksum if config is provided in a volume
+    set:
+      config.dslConfigMap: custom-map
+    asserts:
+      - isNull:
+          path: spec.template.metadata.annotations.checksum/config
+    templates:
+      - deployment.yaml
+
   - it: does not create secret checksum with existing passphrase secret
     set:
       config.passphrase.useExistingSecret: true

--- a/charts/microgateway/tests/deployment_test.yaml
+++ b/charts/microgateway/tests/deployment_test.yaml
@@ -147,7 +147,7 @@ tests:
     templates:
       - deployment.yaml
 
-  - it: uses existing config map volume
+  - it: uses existing ConfigMap volume
     set: 
       config:
         dslConfigMap: existingMap

--- a/charts/microgateway/tests/deployment_test.yaml
+++ b/charts/microgateway/tests/deployment_test.yaml
@@ -147,6 +147,18 @@ tests:
     templates:
       - deployment.yaml
 
+  - it: uses existing config map volume
+    set: 
+      config:
+        dslConfigMap: existingMap
+      asserts:
+      - equal:
+          path: spec.template.spec.volumes[0].name
+          value: config
+      - equal:
+          path: spec.template.spec.volumes[0].configMap.name
+          value: existingMap
+
   - it: does create extra volumes
     set:
       extraVolumes:

--- a/charts/microgateway/values.yaml
+++ b/charts/microgateway/values.yaml
@@ -80,11 +80,11 @@ config:
 
   # config.dslConfigMap -- Name of a config map containing the Microgateway DSL configuration file. <br>
   # The DSL is expected in a data entry called `config.yaml`. <br> <br>
-  # Template rendering fails if both `config.dslConfigMap`and `config.dsl` are specified. 
+  # Template rendering fails if both `config.dslConfigMap`and `config.dsl` are specified.
   # @default -- ""
   dslConfigMap:
   # config.dsl -- [DSL configuration](#dsl-configuration)
-  # Template rendering fails if both `config.dslConfigMap`and `config.dsl` are specified. 
+  # Template rendering fails if both `config.dslConfigMap`and `config.dsl` are specified.
   dsl: {}
 
 # commonLabels -- Labels to add to all resources.

--- a/charts/microgateway/values.yaml
+++ b/charts/microgateway/values.yaml
@@ -77,7 +77,14 @@ config:
     # config.license.key -- The Airlock Microgateway license key which will be stored and used in a secret.
     # @default -- ""
     key:
+
+  # config.dslConfigMap -- Name of a config map containing the Microgateway DSL configuration file. <br>
+  # The DSL is expected in a data entry called `config.yaml`. <br> <br>
+  # Template rendering fails if both `config.dslConfigMap`and `config.dsl` are specified. 
+  # @default -- ""
+  dslConfigMap:
   # config.dsl -- [DSL configuration](#dsl-configuration)
+  # Template rendering fails if both `config.dslConfigMap`and `config.dsl` are specified. 
   dsl: {}
 
 # commonLabels -- Labels to add to all resources.

--- a/charts/microgateway/values.yaml
+++ b/charts/microgateway/values.yaml
@@ -78,13 +78,13 @@ config:
     # @default -- ""
     key:
 
-  # config.dslConfigMap -- Name of a config map containing the Microgateway DSL configuration file. <br>
+  # config.dslConfigMap -- Name of the ConfigMap containing the Microgateway DSL configuration file. <br>
   # The DSL is expected in a data entry called `config.yaml`. <br> <br>
-  # Template rendering fails if both `config.dslConfigMap`and `config.dsl` are specified.
+  # Template rendering fails if `config.dslConfigMap` and `config.dsl` are specified.
   # @default -- ""
   dslConfigMap:
   # config.dsl -- [DSL configuration](#dsl-configuration)
-  # Template rendering fails if both `config.dslConfigMap`and `config.dsl` are specified.
+  # Template rendering fails if `config.dslConfigMap` and `config.dsl` are specified.
   dsl: {}
 
 # commonLabels -- Labels to add to all resources.


### PR DESCRIPTION
# Pull Request Template

## Description

Add option to mount an existing ConfigMap containing the DSL file into the Microgateway Pod.

## Type of change

- [X] Feature (non-breaking change)

## How has this been tested?
Please describe the tests you ran in addition to the unit tests. Provide instructions to re-run the tests. Please list any relevant details for test setup.


**Versions**
* Microgateway:
* Helm Chart:
* Helm client:
* Kubernetes / Openshift:

## Checklist:
- [x] Unit tests have been implemented.

