### PR TITLE
Add deprecation notice with references to Airlock Microgateway 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# DEPRECATED
+
+This repository was deprecated on 2024-11-08. It is no longer maintained. As a replacement we offer [Airlock Microgateway](https://docs.airlock.com/microgateway/latest/)
+in version 4.4 and higher which is a Kubernetes native WAAP solution.
+
+Refer to our Helm Charts [Airlock Microgateway](https://quay.io/repository/airlockcharts/microgateway) and [Airlock Microgateway CNI](https://quay.io/repository/airlockcharts/microgateway-cni) or visit us at [GitHub](https://github.com/airlock/microgateway).
+
+
 # Airlock Secure Access Hub
 This repository contains Helm Charts for the [Airlock Secure Access Hub](https://www.airlock.com/). These charts are used to perform the container-based deployment.
 


### PR DESCRIPTION
Add deprecation notice with references to Airlock Microgateway 4
